### PR TITLE
feat: Implement note event handling and add tests

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/RandomCommentMessage.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/RandomCommentMessage.kt
@@ -1,0 +1,71 @@
+package net.raquezha.nuecagram.webhook
+
+class RandomCommentMessage {
+    private val commentMessages =
+        mutableListOf(
+            "dropped a comment on the",
+            "commented on the",
+            "left a note on the",
+            "wanted to add some thoughts on the",
+            "has a question about the",
+            "needs clarification on the",
+            "suggested a change to the",
+            "proposed an update to the",
+            "fixed a typo in the",
+            "shared a helpful resource for the",
+            "identified an issue with the",
+            "provided feedback on the",
+            "requested changes for the",
+            "reviewed the",
+            "pointed out an improvement for the",
+            "highlighted an issue with the",
+            "noted the",
+            "asked for more details on the",
+            "raised a concern about the",
+            "offered suggestions for the",
+            "notified about the",
+            "made a suggestion for the",
+            "addressed a concern with the",
+            "inquired about the",
+            "submitted a comment on the",
+            "replied with feedback on the",
+            "voiced a suggestion for the",
+            "requested clarification on the",
+            "chimed in on the",
+            "requested a review of the",
+            "added a note to the",
+            "included thoughts on the",
+            "shared insights on the",
+            "raised a point about the",
+            "highlighted a concern with the",
+            "commented with suggestions on the",
+            "noted a potential problem with the",
+            "commented on the implementation of the",
+            "shared thoughts about the",
+            "commented on the progress of the",
+            "requested an update on the",
+            "suggested improvements for the",
+            "pointed out a flaw in the",
+            "asked for updates on the",
+            "commented on the quality of the",
+            "noted concerns with the",
+            "requested more information on the",
+            "noted a concern with the",
+            "asked a question about the",
+            "provided input on the",
+            "offered a perspective on the",
+            "requested feedback on the",
+            "commented on the",
+        )
+    private var currentIndex = 0
+
+    init {
+        commentMessages.shuffle()
+    }
+
+    fun getRandomComment(): String {
+        val comment = commentMessages[currentIndex]
+        currentIndex = (currentIndex + 1) % commentMessages.size
+        return comment
+    }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/BaseEventTestHelper.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/BaseEventTestHelper.kt
@@ -90,6 +90,7 @@ abstract class BaseEventTestHelper : KoinTest {
         const val EVENT_JOB = "Job Hook"
         const val EVENT_DEPLOYMENT = "Deployment Hook"
         const val EVENT_RELEASE = "Release Hook"
+        const val EVENT_NOTE = "Note Hook"
 
         @BeforeClass
         @JvmStatic

--- a/src/test/kotlin/net/raquezha/nuecagram/NoteEventWebhookTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/NoteEventWebhookTest.kt
@@ -1,0 +1,125 @@
+package net.raquezha.nuecagram
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.server.testing.testApplication
+import org.junit.Test
+
+class NoteEventWebhookTest : BaseEventTestHelper() {
+    @Test
+    fun testWebhookMergeEvent() =
+        testApplication {
+            configureTestApplication()
+            val response = postWebhook(EVENT_NOTE, SAMPLE_PAYLOAD)
+            assertThat(response).isEqualTo("Webhook received successfully")
+        }
+
+    companion object {
+        val SAMPLE_PAYLOAD =
+            """
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {
+    "id": 38,
+    "name": "raquezha",
+    "username": "raquezha",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/38/avatar.png",
+    "email": "[REDACTED]"
+  },
+  "project_id": 327,
+  "project": {
+    "id": 327,
+    "name": "Kotlin Practice",
+    "description": null,
+    "web_url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "git_http_url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice.git",
+    "namespace": "2024-batch2",
+    "visibility_level": 0,
+    "path_with_namespace": "android-team/interns/2024-batch2/kotlin-practice",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice",
+    "url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "ssh_url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "http_url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice.git"
+  },
+  "object_attributes": {
+    "attachment": null,
+    "author_id": 38,
+    "change_position": {
+      "base_sha": null,
+      "start_sha": null,
+      "head_sha": null,
+      "old_path": null,
+      "new_path": null,
+      "position_type": "text",
+      "old_line": null,
+      "new_line": null,
+      "line_range": null
+    },
+    "commit_id": "c2b4f233acab45629c41f0a363b879a7cb59841c",
+    "created_at": "2024-07-01 08:52:18 UTC",
+    "discussion_id": "61443987ed14977eb95fd5a761e5a6fcc506dc8e",
+    "id": 72057,
+    "line_code": "08ae6361b0035d1fdb7df6669ef0ce6273ffed2f_0_25",
+    "note": "sample comment",
+    "noteable_id": null,
+    "noteable_type": "Commit",
+    "original_position": {
+      "base_sha": "edff1b0eac8f3b85f8e8ea63738d90a728470012",
+      "start_sha": "edff1b0eac8f3b85f8e8ea63738d90a728470012",
+      "head_sha": "c2b4f233acab45629c41f0a363b879a7cb59841c",
+      "old_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "new_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "position_type": "text",
+      "old_line": null,
+      "new_line": 25,
+      "line_range": null
+    },
+    "position": {
+      "base_sha": "1231231312312312312312312312",
+      "start_sha": "1231231312312312312312312312",
+      "head_sha": "1232132131231231231231231",
+      "old_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "new_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "position_type": "text",
+      "old_line": null,
+      "new_line": 25,
+      "line_range": null
+    },
+    "project_id": 327,
+    "resolved_at": null,
+    "resolved_by_id": null,
+    "resolved_by_push": null,
+    "st_diff": null,
+    "system": false,
+    "type": "DiffNote",
+    "updated_at": "2024-07-01 08:52:18 UTC",
+    "updated_by_id": null,
+    "description": "sample comment",
+    "url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice/-/commit/c2b4f233acab45629c41f0a363b879a7cb59841c#note_72057",
+    "action": "create"
+  },
+  "repository": {
+    "name": "Kotlin Practice",
+    "url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "description": null,
+    "homepage": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice"
+  },
+  "commit": {
+    "id": "1231313131313131231312",
+    "message": "problem set easy exercises\n",
+    "title": "problem set easy exercises",
+    "timestamp": "2024-07-01T10:46:10+08:00",
+    "url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice/-/commit/12312321321231231231231",
+    "author": {
+      "name": "sdafdasfasfas",
+      "email": "[REDACTED]"
+    }
+  }
+}
+            """.trimIndent()
+    }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/api/note-event-1comment-on-commit.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/note-event-1comment-on-commit.http
@@ -1,0 +1,116 @@
+POST http://localhost:8080/webhook
+Content-Type: application/json
+User-Agent: GitLab/16.11.2-ee
+X-Gitlab-Event: Note Hook
+X-Gitlab-Webhook-UUID: 4934cc87-96a7-401b-8256-4aa3ea1c8f74
+X-Gitlab-Instance: https://gitlab.com
+X-Gitlab-Token: [REDACTED]
+X-Gitlab-Event-UUID: 04862d56-febc-4be8-8339-be10e5120f02
+X-Nuecagram-Token: {{X-Nuecagram-Token}}
+X-Nuecagram-Chat-Id: {{X-Nuecagram-Chat-Id}}
+X-Nuecagram-Topic-Id: {{X-Nuecagram-Topic-Id}}
+
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {
+    "id": 38,
+    "name": "raquezha",
+    "username": "raquezha",
+    "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/38/avatar.png",
+    "email": "[REDACTED]"
+  },
+  "project_id": 327,
+  "project": {
+    "id": 327,
+    "name": "Kotlin Practice",
+    "description": null,
+    "web_url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice",
+    "avatar_url": null,
+    "git_ssh_url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "git_http_url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice.git",
+    "namespace": "2024-batch2",
+    "visibility_level": 0,
+    "path_with_namespace": "android-team/interns/2024-batch2/kotlin-practice",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice",
+    "url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "ssh_url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "http_url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice.git"
+  },
+  "object_attributes": {
+    "attachment": null,
+    "author_id": 38,
+    "change_position": {
+      "base_sha": null,
+      "start_sha": null,
+      "head_sha": null,
+      "old_path": null,
+      "new_path": null,
+      "position_type": "text",
+      "old_line": null,
+      "new_line": null,
+      "line_range": null
+    },
+    "commit_id": "c2b4f233acab45629c41f0a363b879a7cb59841c",
+    "created_at": "2024-07-01 08:52:18 UTC",
+    "discussion_id": "61443987ed14977eb95fd5a761e5a6fcc506dc8e",
+    "id": 72057,
+    "line_code": "08ae6361b0035d1fdb7df6669ef0ce6273ffed2f_0_25",
+    "note": "Use the `showLoading` as a condition to `postState`\n\n    ```kotlin\n    if (showLoading) {\n  postState { it.copy(isLoading = showLoading) }\n}\n    ```",
+    "noteable_id": null,
+    "noteable_type": "Commit",
+    "original_position": {
+      "base_sha": "edff1b0eac8f3b85f8e8ea63738d90a728470012",
+      "start_sha": "edff1b0eac8f3b85f8e8ea63738d90a728470012",
+      "head_sha": "c2b4f233acab45629c41f0a363b879a7cb59841c",
+      "old_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "new_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "position_type": "text",
+      "old_line": null,
+      "new_line": 25,
+      "line_range": null
+    },
+    "position": {
+      "base_sha": "1231231312312312312312312312",
+      "start_sha": "1231231312312312312312312312",
+      "head_sha": "1232132131231231231231231",
+      "old_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "new_path": "app/src/main/java/com/example/practice_exercises/Problem-Set-Character-Frequency.kt",
+      "position_type": "text",
+      "old_line": null,
+      "new_line": 25,
+      "line_range": null
+    },
+    "project_id": 327,
+    "resolved_at": null,
+    "resolved_by_id": null,
+    "resolved_by_push": null,
+    "st_diff": null,
+    "system": false,
+    "type": "DiffNote",
+    "updated_at": "2024-07-01 08:52:18 UTC",
+    "updated_by_id": null,
+    "description": "sample comment",
+    "url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice/-/commit/c2b4f233acab45629c41f0a363b879a7cb59841c#note_72057",
+    "action": "create"
+  },
+  "repository": {
+    "name": "Kotlin Practice",
+    "url": "git@gitlab.com:android-team/interns/2024-batch2/kotlin-practice.git",
+    "description": null,
+    "homepage": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice"
+  },
+  "commit": {
+    "id": "1231313131313131231312",
+    "message": "problem set easy exercises\n",
+    "title": "problem set easy exercises",
+    "timestamp": "2024-07-01T10:46:10+08:00",
+    "url": "https://gitlab.com/android-team/interns/2024-batch2/kotlin-practice/-/commit/12312321321231231231231",
+    "author": {
+      "name": "sdafdasfasfas",
+      "email": "[REDACTED]"
+    }
+  }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/api/note-event-2comment-on-merge.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/note-event-2comment-on-merge.http
@@ -1,0 +1,158 @@
+POST http://localhost:8080/webhook
+Content-Type: application/json
+User-Agent: GitLab/16.11.2-ee
+X-Gitlab-Event: Note Hook
+X-Gitlab-Webhook-UUID: 4934cc87-96a7-401b-8256-4aa3ea1c8f74
+X-Gitlab-Instance: https://gitlab.com
+X-Gitlab-Token: [REDACTED]
+X-Gitlab-Event-UUID: 04862d56-febc-4be8-8339-be10e5120f02
+X-Nuecagram-Token: {{X-Nuecagram-Token}}
+X-Nuecagram-Chat-Id: {{X-Nuecagram-Chat-Id}}
+X-Nuecagram-Topic-Id: {{X-Nuecagram-Topic-Id}}
+
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon",
+    "email": "admin@example.com"
+  },
+  "project_id": 5,
+  "project":{
+    "id": 5,
+    "name":"Gitlab Test",
+    "description":"Aut reprehenderit ut est.",
+    "web_url":"http://example.com/gitlab-org/gitlab-test",
+    "avatar_url":null,
+    "git_ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+    "git_http_url":"http://example.com/gitlab-org/gitlab-test.git",
+    "namespace":"Gitlab Org",
+    "visibility_level":10,
+    "path_with_namespace":"gitlab-org/gitlab-test",
+    "default_branch":"master",
+    "homepage":"http://example.com/gitlab-org/gitlab-test",
+    "url":"http://example.com/gitlab-org/gitlab-test.git",
+    "ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+    "http_url":"http://example.com/gitlab-org/gitlab-test.git"
+  },
+  "repository":{
+    "name": "Gitlab Test",
+    "url": "http://localhost/gitlab-org/gitlab-test.git",
+    "description": "Aut reprehenderit ut est.",
+    "homepage": "http://example.com/gitlab-org/gitlab-test"
+  },
+  "object_attributes": {
+    "id": 1244,
+    "note": "This MR needs work.",
+    "noteable_type": "MergeRequest",
+    "author_id": 1,
+    "created_at": "2015-05-17 18:21:36 UTC",
+    "updated_at": "2015-05-17 18:21:36 UTC",
+    "project_id": 5,
+    "attachment": null,
+    "line_code": null,
+    "commit_id": "",
+    "noteable_id": 7,
+    "system": false,
+    "st_diff": null,
+    "action": "create",
+    "url": "http://example.com/gitlab-org/gitlab-test/merge_requests/1#note_1244"
+  },
+  "merge_request": {
+    "id": 7,
+    "target_branch": "markdown",
+    "source_branch": "master",
+    "source_project_id": 5,
+    "author_id": 8,
+    "assignee_id": 28,
+    "title": "Tempora et eos debitis quae laborum et.",
+    "created_at": "2015-03-01 20:12:53 UTC",
+    "updated_at": "2015-03-21 18:27:27 UTC",
+    "milestone_id": 11,
+    "state": "opened",
+    "merge_status": "cannot_be_merged",
+    "target_project_id": 5,
+    "iid": 1,
+    "description": "Et voluptas corrupti assumenda temporibus. Architecto cum animi eveniet amet asperiores. Vitae numquam voluptate est natus sit et ad id.",
+    "position": 0,
+    "labels": [
+      {
+        "id": 25,
+        "title": "Afterpod",
+        "color": "#3e8068",
+        "project_id": null,
+        "created_at": "2019-06-05T14:32:20.211Z",
+        "updated_at": "2019-06-05T14:32:20.211Z",
+        "template": false,
+        "description": null,
+        "type": "GroupLabel",
+        "group_id": 4
+      },
+      {
+        "id": 86,
+        "title": "Element",
+        "color": "#231afe",
+        "project_id": 4,
+        "created_at": "2019-06-05T14:32:20.637Z",
+        "updated_at": "2019-06-05T14:32:20.637Z",
+        "template": false,
+        "description": null,
+        "type": "ProjectLabel",
+        "group_id": null
+      }
+    ],
+    "source":{
+      "name":"Gitlab Test",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/gitlab-org/gitlab-test",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+      "git_http_url":"http://example.com/gitlab-org/gitlab-test.git",
+      "namespace":"Gitlab Org",
+      "visibility_level":10,
+      "path_with_namespace":"gitlab-org/gitlab-test",
+      "default_branch":"master",
+      "homepage":"http://example.com/gitlab-org/gitlab-test",
+      "url":"http://example.com/gitlab-org/gitlab-test.git",
+      "ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+      "http_url":"http://example.com/gitlab-org/gitlab-test.git"
+    },
+    "target": {
+      "name":"Gitlab Test",
+      "description":"Aut reprehenderit ut est.",
+      "web_url":"http://example.com/gitlab-org/gitlab-test",
+      "avatar_url":null,
+      "git_ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+      "git_http_url":"http://example.com/gitlab-org/gitlab-test.git",
+      "namespace":"Gitlab Org",
+      "visibility_level":10,
+      "path_with_namespace":"gitlab-org/gitlab-test",
+      "default_branch":"master",
+      "homepage":"http://example.com/gitlab-org/gitlab-test",
+      "url":"http://example.com/gitlab-org/gitlab-test.git",
+      "ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+      "http_url":"http://example.com/gitlab-org/gitlab-test.git"
+    },
+    "last_commit": {
+      "id": "562e173be03b8ff2efb05345d12df18815438a4b",
+      "message": "Merge branch 'another-branch' into 'master'\n\nCheck in this test\n",
+      "timestamp": "2024-06-11T03:04:03+00:00",
+      "url": "http://example.com/gitlab-org/gitlab-test/commit/562e173be03b8ff2efb05345d12df18815438a4b",
+      "author": {
+        "name": "John Smith",
+        "email": "john@example.com"
+      }
+    },
+    "work_in_progress": false,
+    "draft": false,
+    "assignee": {
+      "name": "User1",
+      "username": "user1",
+      "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon"
+    },
+    "detailed_merge_status": "checking"
+  }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/api/note-event-3comment-on-issue.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/note-event-3comment-on-issue.http
@@ -1,0 +1,106 @@
+POST http://localhost:8080/webhook
+Content-Type: application/json
+User-Agent: GitLab/16.11.2-ee
+X-Gitlab-Event: Note Hook
+X-Gitlab-Webhook-UUID: 4934cc87-96a7-401b-8256-4aa3ea1c8f74
+X-Gitlab-Instance: https://gitlab.com
+X-Gitlab-Token: [REDACTED]
+X-Gitlab-Event-UUID: 04862d56-febc-4be8-8339-be10e5120f02
+X-Nuecagram-Token: {{X-Nuecagram-Token}}
+X-Nuecagram-Chat-Id: {{X-Nuecagram-Chat-Id}}
+X-Nuecagram-Topic-Id: {{X-Nuecagram-Topic-Id}}
+
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {
+    "id": 1,
+    "name": "Administrator",
+    "username": "root",
+    "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=40\u0026d=identicon",
+    "email": "admin@example.com"
+  },
+  "project_id": 5,
+  "project":{
+    "id": 5,
+    "name":"Gitlab Test",
+    "description":"Aut reprehenderit ut est.",
+    "web_url":"http://example.com/gitlab-org/gitlab-test",
+    "avatar_url":null,
+    "git_ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+    "git_http_url":"http://example.com/gitlab-org/gitlab-test.git",
+    "namespace":"Gitlab Org",
+    "visibility_level":10,
+    "path_with_namespace":"gitlab-org/gitlab-test",
+    "default_branch":"master",
+    "homepage":"http://example.com/gitlab-org/gitlab-test",
+    "url":"http://example.com/gitlab-org/gitlab-test.git",
+    "ssh_url":"git@example.com:gitlab-org/gitlab-test.git",
+    "http_url":"http://example.com/gitlab-org/gitlab-test.git"
+  },
+  "repository":{
+    "name":"diaspora",
+    "url":"git@example.com:mike/diaspora.git",
+    "description":"",
+    "homepage":"http://example.com/mike/diaspora"
+  },
+  "object_attributes": {
+    "id": 1241,
+    "note": "Hello world",
+    "noteable_type": "Issue",
+    "author_id": 1,
+    "created_at": "2015-05-17 17:06:40 UTC",
+    "updated_at": "2015-05-17 17:06:40 UTC",
+    "project_id": 5,
+    "attachment": null,
+    "line_code": null,
+    "commit_id": "",
+    "noteable_id": 92,
+    "system": false,
+    "st_diff": null,
+    "action": "create",
+    "url": "http://example.com/gitlab-org/gitlab-test/issues/17#note_1241"
+  },
+  "issue": {
+    "id": 92,
+    "title": "test",
+    "assignee_ids": [],
+    "assignee_id": null,
+    "author_id": 1,
+    "project_id": 5,
+    "created_at": "2015-04-12 14:53:17 UTC",
+    "updated_at": "2015-04-26 08:28:42 UTC",
+    "position": 0,
+    "branch_name": null,
+    "description": "test",
+    "milestone_id": null,
+    "state": "closed",
+    "iid": 17,
+    "labels": [
+      {
+        "id": 25,
+        "title": "Afterpod",
+        "color": "#3e8068",
+        "project_id": null,
+        "created_at": "2019-06-05T14:32:20.211Z",
+        "updated_at": "2019-06-05T14:32:20.211Z",
+        "template": false,
+        "description": null,
+        "type": "GroupLabel",
+        "group_id": 4
+      },
+      {
+        "id": 86,
+        "title": "Element",
+        "color": "#231afe",
+        "project_id": 4,
+        "created_at": "2019-06-05T14:32:20.637Z",
+        "updated_at": "2019-06-05T14:32:20.637Z",
+        "template": false,
+        "description": null,
+        "type": "ProjectLabel",
+        "group_id": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Added `getUrl` and `formatFinishedAt` helper functions for URL generation and date formatting.
- Improved `formatNoteEvent` to handle ISSUE, MERGE_REQUEST, and COMMIT noteable types with `generateNoteMessage` method.
- Skipped SNIPPET type handling.
- Expanded `RandomCommentMessage` class with shuffled comment messages.
- Added unit tests and HTTP tests to ensure functionality.

Implements #8