### PR TITLE
Job and Pipeline Event Message Format

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
@@ -61,7 +61,7 @@ class WebhookMessageFormatter {
         if (event.buildStatus in listOf("success", "created")) {
             throw SkipEventException()
         }
-        val jobUrl = event.getJobUrl().link("#${event.buildId}")
+        val jobUrl = event.getPipelineUrl().link("#${event.buildId}")
         return buildString {
             append("Job ${event.buildName.bold()} $jobUrl ")
             append("triggered by ${event.user.name.bold()} ")
@@ -90,11 +90,13 @@ class WebhookMessageFormatter {
     @Suppress("UnusedReceiverParameter")
     private fun BuildEvent.runningStatus(): String = "started running. Only time will tell when will it be finished."
 
-    private fun BuildEvent.getJobUrl(): String = "${repository.homepage}/-/jobs/$buildId"
+    private fun BuildEvent.getPipelineUrl(): String = "${repository.homepage}/-/jobs/$buildId"
 
     private fun NoteEvent.getUrl(label: String): String = objectAttributes.url.link(label)
 
     private fun Date?.formatFinishedAt(): String = this?.let { SimpleDateFormat("hh:mm a 'on' MMMM dd, yyyy").format(it) } ?: "N/A"
+
+    private fun PipelineEvent.getPipelineUrl(): String = "${project.webUrl}-/pipelines/${objectAttributes.id}"
 
     private fun formatNoteEvent(event: NoteEvent): String {
         val randomCommentMessage = RandomCommentMessage()
@@ -135,7 +137,8 @@ class WebhookMessageFormatter {
         val status = event.objectAttributes.status
         val projectName = event.project.name
         val ref = event.objectAttributes.ref
-        val clickablePipeline = event.project.webUrl.link("#${event.objectAttributes.id}".bold())
+
+        val clickablePipeline = event.getPipelineUrl().link("#${event.objectAttributes.id}".bold())
 
         return buildString {
             append("Pipeline $clickablePipeline for branch ${ref.bold()} ")

--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
@@ -63,7 +63,7 @@ class WebhookMessageFormatter {
         }
         val jobUrl = event.getJobUrl().link("#${event.buildId}")
         return buildString {
-            append("Job ${event.buildName.bold()}$jobUrl ")
+            append("Job ${event.buildName.bold()} $jobUrl ")
             append("triggered by ${event.user.name.bold()} ")
             append("in project ${event.repository.name.bold()} has ")
             append(event.getBuildStatusMessage())


### PR DESCRIPTION
Apply changes for the message of Job and Pipeline Events

1. Add space between Job and Job id. Sample:  `Job deploy #523320 triggered by raquezha has etc. etc...`
2. Fix url redirection for Pipeline Failure. Clicking Pipeline Id will now redirect you to right pipeline page instead of repository itself.