### PR TITLE
Resolve issue #23

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
@@ -311,8 +311,8 @@ class WebhookMessageFormatter {
     private fun formatMergeRequestEventMessage(event: MergeRequestEvent): String =
         formatActionWithTitleAndDescription(
             user = event.user.name,
-            action = event.objectAttributes.state,
-            link = "merge request${event.objectAttributes.url.link("#${event.objectAttributes.id}")}",
+            action = getFormattedAction(event.objectAttributes.action),
+            link = "${event.objectAttributes.url.link("merge request#${event.objectAttributes.id}")}",
             repositoryName = event.repository.name,
             title = event.objectAttributes.title,
             description = event.objectAttributes.description,
@@ -347,6 +347,11 @@ class WebhookMessageFormatter {
             "open" -> "opened"
             "close" -> "closed"
             "reopen" -> "reopened"
+            "approved" -> "approved"
+            "unapproved" -> "unapproved"
+            "approval" -> "approval"
+            "unapproval" -> "unapproval"
+            "merge" -> "merged"
             else -> throw SkipEventException()
         }
 }


### PR DESCRIPTION
`formatMergeRequestEventMessage()`'s `event.objectAttributes.state` never changes; it is always `opened`.

![Screenshot from 2024-09-16 09-47-18](https://github.com/user-attachments/assets/1dec84cc-5e26-4d93-9874-ed45c847fe6d)

From the [GitLab docs](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events), `object_attributes.action` is used to see what actions are done.

![Screenshot from 2024-09-16 09-47-47](https://github.com/user-attachments/assets/cf1e186e-0a6a-44e4-bb8c-a8f1080105ff)

With that, we reuse `getFormattedAction()` and pass `event.objectAttributes.action`, much like the others.

![Screenshot from 2024-09-16 09-27-13](https://github.com/user-attachments/assets/8f841a6c-d390-46f7-a796-14608a60afc2)
