### PR TITLE
Only run `java-run` service once `gradle-build` is complete

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,8 @@ services:
     working_dir: /app
     command: java -jar nuecagram-fat.jar
     depends_on:
-      - gradle-build
+      gradle-build:
+        condition: service_completed_successfully
     networks:
       - app-network
   


### PR DESCRIPTION
Looks like I forgot to add this in the `compose.yaml` file. This should fix the issue of `java-run` exiting out with an error due to `gradle-build` not finishing the build yet (so therefore no JAR file for `java-run` to run)