### PR TITLE
Implement #10

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
@@ -9,17 +9,12 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import net.raquezha.nuecagram.telegram.Message
-import net.raquezha.nuecagram.telegram.TelegramService
 import net.raquezha.nuecagram.webhook.EventData
 import net.raquezha.nuecagram.webhook.SkipEventException
 import net.raquezha.nuecagram.webhook.WebHookService
-import net.raquezha.nuecagram.webhook.WebhookMessageFormatter
-import org.gitlab4j.api.webhook.BuildEvent
+import net.raquezha.nuecagram.webhook.WebhookRequestHandler
 import org.koin.ktor.ext.inject
 
 fun Application.configureRouting() {
@@ -57,66 +52,7 @@ fun Application.configureRouting() {
         }
 
         this@configureRouting.launch {
-            this@configureRouting.processQueue(requestQueue)
+            WebhookRequestHandler(this@configureRouting).processQueue(requestQueue)
         }
     }
-}
-
-suspend fun Application.processQueue(queue: Channel<EventData>) {
-    val webhookService by inject<WebHookService>()
-    val logger by inject<KLogger>()
-    val telegramService by inject<TelegramService>()
-    val formatter: WebhookMessageFormatter by inject()
-
-    logger.debug { "processing queue" }
-    for (data in queue) {
-        try {
-            val event = data.event
-            val chatDetails = data.chatDetails()
-
-            coroutineScope {
-                val sendMessageJob =
-                    async {
-                        telegramService.sendMessage(
-                            Message(
-                                chatId = chatDetails.chatId,
-                                threadId = chatDetails.topicId,
-                                messageId =
-                                    if (event is BuildEvent) {
-                                        webhookService.getMessageIdOfEvent(event.buildId)
-                                    } else {
-                                        null
-                                    },
-                                text = formatter.formatEventMessage(event),
-                                parseMode = "HTML",
-                                disableWebPagePreview = true,
-                            ),
-                        )
-                    }
-                val messageId = sendMessageJob.await() // Ensure sendMessage completes before responding
-                logger.debug { "sent message $messageId" }
-
-                if (event is BuildEvent) {
-                    when {
-                        event.buildStatus in listOf("success", "canceled", "failed") -> {
-                            webhookService.clearMessageIdOfEvent(event.buildId)
-                            logger.debug { "build #${event.buildId} finished, removed saved message id" }
-                        }
-                        else -> {
-                            webhookService.setMessageIdOfEvent(event.buildId, messageId)
-                            logger.debug { "saved build #${event.buildId}'s message id $messageId" }
-                        }
-                    }
-                }
-            }
-        } catch (skipEx: SkipEventException) {
-            logger.debug { "skipped event" }
-        } catch (e: Exception) {
-            logger.error { "Error processing webhook data.\n${e.message}" }
-        } finally {
-            // delay a bit for the next request
-            // delay(300)
-        }
-    }
-    logger.debug { "stopped processing queue" }
 }

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/Message.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/Message.kt
@@ -1,5 +1,7 @@
 package net.raquezha.nuecagram.telegram
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -9,6 +11,10 @@ data class Message(
     @get:JsonProperty("chat_id")
     @SerialName("chat_id")
     val chatId: String,
+    @JsonInclude(Include.NON_NULL)
+    @get:JsonProperty("message_id")
+    @SerialName("message_id")
+    val messageId: String? = null,
     @get:JsonProperty("text")
     @SerialName("text")
     val text: String,
@@ -18,6 +24,7 @@ data class Message(
     @SerialName("parse_mode")
     @get:JsonProperty("parse_mode")
     val parseMode: String = "HTML",
+    @JsonInclude(Include.NON_NULL)
     @SerialName("message_thread_id")
     @get:JsonProperty("message_thread_id")
     val threadId: String? = null,

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/MockTelegramService.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/MockTelegramService.kt
@@ -1,7 +1,5 @@
 package net.raquezha.nuecagram.telegram
 
 class MockTelegramService : TelegramService {
-    override suspend fun sendMessage(message: Message) {
-        // Do nothing
-    }
+    override suspend fun sendMessage(message: Message): String = "123"
 }

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramService.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramService.kt
@@ -5,5 +5,7 @@ import java.net.URL
 interface TelegramService {
     fun getURLSendMessage(botToken: String): URL = URL("https://api.telegram.org/bot$botToken/sendMessage")
 
-    suspend fun sendMessage(message: Message)
+    fun getURLEditMessage(botToken: String): URL = URL("https://api.telegram.org/bot$botToken/editMessageText")
+
+    suspend fun sendMessage(message: Message): String
 }

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramServiceImpl.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramServiceImpl.kt
@@ -3,20 +3,43 @@ package net.raquezha.nuecagram.telegram
 import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.contentType
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import net.raquezha.nuecagram.telegram.TokenProviderImpl.TelegramBotToken
+import org.apache.http.HttpException
 import org.gitlab4j.api.utils.JacksonJson
 
 class TelegramServiceImpl(
     private val client: HttpClient,
     private val botToken: TelegramBotToken,
 ) : TelegramService {
-    override suspend fun sendMessage(message: Message) {
+    override suspend fun sendMessage(message: Message): String {
         val jsonMessage = JacksonJson.toJsonString(message)
-        client.post(getURLSendMessage(botToken.value)) {
-            contentType(ContentType.Application.Json)
-            setBody(jsonMessage)
+        val response =
+            when {
+                message.messageId.isNullOrBlank() -> {
+                    client.post(getURLSendMessage(botToken.value)) {
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonMessage)
+                    }
+                }
+                else -> {
+                    client.post(getURLEditMessage(botToken.value)) {
+                        contentType(ContentType.Application.Json)
+                        setBody(jsonMessage)
+                    }
+                }
+            }
+
+        if (response.status != HttpStatusCode.OK) {
+            throw HttpException("Failed to send message")
         }
+
+        val responseJson = JacksonJson.toJsonNode(response.bodyAsText())
+        return responseJson
+            .get("result")
+            .get("message_id")
+            .asInt()
+            .toString()
     }
 }

--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebHookService.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebHookService.kt
@@ -33,4 +33,13 @@ interface WebHookService {
     }
 
     suspend fun handleRequest(call: ApplicationCall): EventData
+
+    fun getMessageIdOfEvent(buildEventId: Long): String?
+
+    fun setMessageIdOfEvent(
+        buildEventId: Long,
+        messageId: String,
+    )
+
+    fun clearMessageIdOfEvent(buildEventId: Long)
 }

--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
@@ -60,7 +60,7 @@ class WebhookMessageFormatter {
     }
 
     private fun formatBuildEventMessage(event: BuildEvent): String {
-        if (event.buildStatus in listOf("success", "created")) {
+        if (event.buildStatus in listOf("created")) {
             throw SkipEventException()
         }
         val jobUrl = event.getPipelineUrl().link("#${event.buildId}")
@@ -78,6 +78,7 @@ class WebhookMessageFormatter {
             "canceled" -> canceledStatus()
             "pending" -> pendingStatus()
             "running" -> runningStatus()
+            "success" -> successStatus()
             else -> throw GitLabApiException("[build status $buildStatus not supported.]")
         }
 
@@ -91,6 +92,8 @@ class WebhookMessageFormatter {
 
     @Suppress("UnusedReceiverParameter")
     private fun BuildEvent.runningStatus(): String = "started running. Only time will tell when will it be finished."
+
+    private fun BuildEvent.successStatus(): String = "finished ${"successfully".bold()}."
 
     private fun BuildEvent.getPipelineUrl(): String = "${repository.homepage}/-/jobs/$buildId"
 

--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookMessageFormatter.kt
@@ -65,6 +65,7 @@ class WebhookMessageFormatter {
         }
         val jobUrl = event.getPipelineUrl().link("#${event.buildId}")
         return buildString {
+            append(event.getBuildStatusEmoji())
             append("Job ${event.buildName.bold()} $jobUrl ")
             append("triggered by ${event.user.name.bold()} ")
             append("in project ${event.repository.name.bold()} has ")
@@ -72,13 +73,25 @@ class WebhookMessageFormatter {
         }
     }
 
+    private fun BuildEvent.getBuildStatusEmoji(): String =
+        when (buildStatus) {
+            "created" -> "✨ "
+            "pending" -> "⏳ "
+            "running" -> "\uD83D\uDFE2 "
+            "success" -> "✅ "
+            "failed" -> "❎ "
+            "canceled" -> "⛔ "
+            else -> ""
+        }
+
     private fun BuildEvent.getBuildStatusMessage(): String =
         when (buildStatus) {
-            "failed" -> failedStatus()
-            "canceled" -> canceledStatus()
+            "created" -> createdStatus()
             "pending" -> pendingStatus()
             "running" -> runningStatus()
             "success" -> successStatus()
+            "failed" -> failedStatus()
+            "canceled" -> canceledStatus()
             else -> throw GitLabApiException("[build status $buildStatus not supported.]")
         }
 
@@ -88,12 +101,15 @@ class WebhookMessageFormatter {
     private fun BuildEvent.canceledStatus(): String = "been ${"canceled".bold()} at ${buildFinishedAt?.formatFinishedAt()}."
 
     @Suppress("UnusedReceiverParameter")
-    private fun BuildEvent.pendingStatus(): String = "been created and in ${"pending".bold()} status."
+    private fun BuildEvent.createdStatus(): String = "been ${"created".bold()}."
 
     @Suppress("UnusedReceiverParameter")
-    private fun BuildEvent.runningStatus(): String = "started running. Only time will tell when will it be finished."
+    private fun BuildEvent.pendingStatus(): String = "went to ${"pending".bold()} status."
 
-    private fun BuildEvent.successStatus(): String = "finished ${"successfully".bold()}."
+    @Suppress("UnusedReceiverParameter")
+    private fun BuildEvent.runningStatus(): String = "started ${"running".bold()}. Only time will tell when will it be finished."
+
+    private fun BuildEvent.successStatus(): String = "finished ${"successfully".bold()} at ${buildFinishedAt?.formatFinishedAt()}."
 
     private fun BuildEvent.getPipelineUrl(): String = "${repository.homepage}/-/jobs/$buildId"
 

--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookRequestHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookRequestHandler.kt
@@ -1,0 +1,77 @@
+package net.raquezha.nuecagram.webhook
+
+import io.github.oshai.kotlinlogging.KLogger
+import io.ktor.server.application.Application
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import net.raquezha.nuecagram.telegram.Message
+import net.raquezha.nuecagram.telegram.TelegramService
+import org.gitlab4j.api.webhook.BuildEvent
+import org.koin.ktor.ext.inject
+
+class WebhookRequestHandler(
+    private val application: Application,
+) {
+    suspend fun processQueue(queue: Channel<EventData>) {
+        val webhookService by application.inject<WebHookService>()
+        val logger by application.inject<KLogger>()
+        val telegramService by application.inject<TelegramService>()
+        val formatter: WebhookMessageFormatter by application.inject()
+
+        logger.debug { MESSAGE_PROCESSING }
+        for (data in queue) {
+            try {
+                val event = data.event
+                val chatDetails = data.chatDetails()
+                val messageId =
+                    when (event) {
+                        is BuildEvent -> webhookService.getMessageIdOfEvent(event.buildId)
+                        else -> null
+                    }
+                coroutineScope {
+                    val sendMessageJob =
+                        async {
+                            telegramService.sendMessage(
+                                Message(
+                                    chatId = chatDetails.chatId,
+                                    threadId = chatDetails.topicId,
+                                    messageId = messageId,
+                                    text = formatter.formatEventMessage(event),
+                                    parseMode = PARSE_MODE,
+                                    disableWebPagePreview = true,
+                                ),
+                            )
+                        }
+                    val messageJob = sendMessageJob.await() // Ensure sendMessage completes before responding
+                    logger.debug { "sent message $messageJob" }
+                    if (event is BuildEvent) {
+                        when {
+                            event.buildStatus in listOf("success", "canceled", "failed") -> {
+                                webhookService.clearMessageIdOfEvent(event.buildId)
+                                logger.debug { "build #${event.buildId} finished, removed saved message id" }
+                            }
+                            else -> {
+                                webhookService.setMessageIdOfEvent(event.buildId, messageJob)
+                                logger.debug { "saved build #${event.buildId}'s message id $messageJob" }
+                            }
+                        }
+                    }
+                }
+            } catch (skipEx: SkipEventException) {
+                logger.debug { MESSAGE_SKIPPED }
+            } catch (e: Exception) {
+                logger.error { "$MESSAGE_ERROR \n${e.message}" }
+            }
+        }
+        logger.debug { MESSAGE_STOPPED }
+    }
+
+    companion object {
+        const val PARSE_MODE = "HTML"
+        const val MESSAGE_PROCESSING = "Queue started processing."
+        const val MESSAGE_STOPPED = "Queue stopped processing."
+        const val MESSAGE_ERROR = "Error processing webhook data."
+        const val MESSAGE_SKIPPED = "This event is skipped."
+    }
+}


### PR DESCRIPTION
Past implementation was to receive a request, and process it on the spot. If there were multiple requests that arrived simultaneously, it would process them both at the same time; which in this issue's case is bad.

Therefore, I used `Channel` as a way to queue up the requests.

Next, I modified `TelegramService` to support [`editMessageText`](https://core.telegram.org/bots/api#editmessagetext) method, and changed `TelegramServiceImpl`'s `sendMessage()` to use the `editMessageText` method when `message_id` is not null.

Then, I modified `WebhookServiceImpl` to save a `Map<Long, String>` which the key is the build ID, and the value is the message ID. `WebhookService` now has three new functions for getting, setting, and removing the message ID. These functions are used in `Routing.kt`.

I haven't fully tested this yet, but it supports `pending`, `running`, `success`, `failed`, and `canceled` statuses. It should also create new messages when the build ID is different. `created` seems to not pop up for some reason, and I don't know why; but I also implemented that status in `WebhookServiceFormatter`.

