### PR TITLE
improvement: Move `Channel` into `WebhookRequestHandler` and use DI

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/di/Module.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/di/Module.kt
@@ -14,6 +14,7 @@ import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.plugin
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.*
 import net.raquezha.nuecagram.ConfigWithSecrets
 import net.raquezha.nuecagram.configWithSecrets
 import net.raquezha.nuecagram.telegram.MockTelegramService
@@ -26,6 +27,7 @@ import net.raquezha.nuecagram.telegram.TokenProviderImpl.TelegramBotToken
 import net.raquezha.nuecagram.webhook.WebHookService
 import net.raquezha.nuecagram.webhook.WebHookServiceImpl
 import net.raquezha.nuecagram.webhook.WebhookMessageFormatter
+import net.raquezha.nuecagram.webhook.WebhookRequestHandler
 import org.koin.dsl.module
 import org.koin.java.KoinJavaComponent.inject
 
@@ -37,6 +39,7 @@ fun appModule() =
         provideTokenProvider,
         provideHttpClient,
         provideConfigModule,
+        provideWebhookRequestHandler,
     )
 
 fun testAppModule() =
@@ -165,5 +168,12 @@ val provideWebhookModule =
         single<WebHookService> {
             val tokenProvider: TokenProvider by inject()
             WebHookServiceImpl(tokenProvider.getSecretToken(), get())
+        }
+    }
+
+val provideWebhookRequestHandler =
+    module {
+        single { params ->
+            WebhookRequestHandler(application = params.get<Application>())
         }
     }

--- a/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookRequestHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/webhook/WebhookRequestHandler.kt
@@ -13,7 +13,13 @@ import org.koin.ktor.ext.inject
 class WebhookRequestHandler(
     private val application: Application,
 ) {
-    suspend fun processQueue(queue: Channel<EventData>) {
+    private val queue = Channel<EventData>()
+
+    suspend fun enqueue(eventData: EventData) {
+        queue.send(eventData)
+    }
+
+    suspend fun processQueue() {
         val webhookService by application.inject<WebHookService>()
         val logger by application.inject<KLogger>()
         val telegramService by application.inject<TelegramService>()


### PR DESCRIPTION
Just more cleanup of code. Not a priority to push.

- `requestQueue` should not be implemented in `Application.configureRouting()`; should only be in `WebhookRequestHandler` instead.
- Use `koin` to initialize `WebhookRequestHandler`.