### PR TITLE
draft: migrate Nuecagram deployment to DigitalOcean via SSH

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -104,5 +104,27 @@ jobs:
           asset_name: nuecagram-${{ steps.create_release.outputs.clean_tag }}.jib.tar
           asset_content_type: application/x-tar
 
+  deploy-to-droplet:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to DigitalOcean Droplet
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DROPLET_IP }}
+          username: ${{ secrets.DROPLET_USERNAME }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          script: |
+            docker pull raquezha/nuecagram:latest
+            docker stop nuecagram || true
+            docker rm nuecagram || true
+            # Assuming you created a .env file on the droplet at /root/nuecagram.env 
+            # with TELEGRAM_BOT_TOKEN and NUECAGRAM_SECRET_TOKEN
+            docker run -d --name nuecagram \
+              -p 8080:8080 \
+              --env-file /root/nuecagram.env \
+              --restart unless-stopped \
+              raquezha/nuecagram:latest
+
 
 


### PR DESCRIPTION
## Summary

Adds an initial GitHub Actions deployment job that connects to a DigitalOcean Droplet after the Docker Hub publication job and restarts the Nuecagram container.

## Changes

- Adds a deployment job after image publication.
- Pulls the Nuecagram Docker image on the Droplet.
- Restarts the container with the server-local environment file.

## Required repository/server configuration

GitHub repository secrets:

- `DROPLET_IP`
- `DROPLET_USERNAME`
- `DROPLET_SSH_KEY`

Private Droplet configuration:

- Docker installed and authenticated to pull the image.
- `/root/nuecagram.env` containing application secrets.

## Important limitations

This is an **initial deployment draft**, not the final production deployment design. It currently deploys `latest` and does not yet provide immutable-tag deployment, protected GitHub Environment approvals, strict SSH host-key verification, migration/readiness checks, or rollback.

Those production requirements are tracked in **#49**, implementation slice S9. This PR must not be presented as the completed production deployment solution.

## Validation

- [ ] Review workflow syntax and secret names.
- [ ] Validate against a non-production Droplet.
- [ ] Do not merge for production until #49 S9 replaces this with immutable, readiness-checked, rollback-safe deployment.
