### PR TITLE
feat: add session-backed management UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ For long answers, always include a **TLDR;** at the top.
 
 ## Commit/Push Gate (Required)
 - Before every commit or push, run the full local gate: `./gradlew lintKotlinMain lintKotlinTest detekt test build`.
+- Also run the CI-equivalent clean test job: `./gradlew clean test`.
+- If you changed tests, routing, shared fixtures, static/global state, or system-property/env-based config, run `./gradlew clean test` twice before push to catch order-dependent flakes.
 - If any part of that gate fails, do not commit, do not push, and fix the failure first.
 - If a change touches one focused test area, you may run that focused test first for speed, but the full gate still must pass before commit/push.
 - Treat CI as confirmation, not first discovery. Catch lint, test, and build failures locally before sending them upstream.

--- a/src/main/kotlin/net/raquezha/nuecagram/Config.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/Config.kt
@@ -9,3 +9,12 @@ data class Config(
     val host: String,
     val port: Int,
 )
+
+fun configuredBasePath(): String =
+    (System.getProperty("nuecagram.basePath") ?: System.getenv("NUECAGRAM_BASE_PATH") ?: "/nuecagram")
+        .trim()
+        .removeSuffix("/")
+        .ifBlank { "/nuecagram" }
+        .also {
+            require(it.startsWith('/')) { "NUECAGRAM_BASE_PATH must start with '/'" }
+        }

--- a/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
@@ -38,6 +38,11 @@ data class ConsumedManagementLink(
     val installationId: UUID,
 )
 
+data class ManagementSessionContext(
+    val sessionId: UUID,
+    val installationId: UUID,
+)
+
 data class InstallationContext(
     val secretId: UUID,
     val installationId: UUID,
@@ -354,14 +359,148 @@ class InstallationRepository(
                 statement.setInstant(PARAM_1, now)
                 statement.setObject(PARAM_2, match.id)
                 statement.setInstant(PARAM_3, now)
-                if (statement.executeUpdate() == 1) ConsumedManagementLink(match.id, match.installationId) else null
+                if (statement.executeUpdate() == 1) {
+                    ConsumedManagementLink(match.id, match.installationId)
+                } else {
+                    null
+                }
             }
+        }
+
+    @Suppress("LongMethod")
+    suspend fun exchangeManagementLinkForSession(
+        raw: String,
+        sessionExpiresAt: Instant,
+        now: Instant = Instant.now(),
+    ): IssuedCredential? =
+        databaseFactory.dbQuery { connection ->
+            data class Candidate(
+                val id: UUID,
+                val installationId: UUID,
+                val digest: ByteArray,
+                val hash: String,
+            )
+            val candidates = mutableListOf<Candidate>()
+            connection.prepareStatement(
+                """
+                SELECT id, installation_id, token_digest, token_hash
+                FROM management_links
+                WHERE consumed_at IS NULL AND expires_at > ? AND token_digest = ?
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setInstant(PARAM_1, now)
+                statement.setBytes(PARAM_2, CredentialCodec.digest(raw))
+                statement.executeQuery().use { result ->
+                    while (result.next()) {
+                        val hash = result.getString("token_hash") ?: continue
+                        candidates += Candidate(
+                            id = result.getObject("id", UUID::class.java),
+                            installationId = result.getObject("installation_id", UUID::class.java),
+                            digest = result.getBytes("token_digest"),
+                            hash = hash,
+                        )
+                    }
+                }
+            }
+            val match =
+                candidates.firstOrNull { CredentialCodec.matches(raw, it.digest, it.hash) }
+                    ?: return@dbQuery null
+            val sessionId = UUID.randomUUID()
+            val (sessionRaw, stored) = CredentialCodec.issueCredential()
+            val previousAutoCommit = connection.autoCommit
+            connection.autoCommit = false
+            try {
+                val consumed =
+                    connection.prepareStatement(
+                        """
+                        UPDATE management_links
+                        SET consumed_at = ?
+                        WHERE id = ? AND consumed_at IS NULL AND expires_at > ?
+                        """.trimIndent(),
+                    ).use { statement ->
+                        statement.setInstant(PARAM_1, now)
+                        statement.setObject(PARAM_2, match.id)
+                        statement.setInstant(PARAM_3, now)
+                        statement.executeUpdate() == 1
+                    }
+                if (!consumed) {
+                    connection.rollback()
+                    return@dbQuery null
+                }
+                connection.prepareStatement(
+                    """
+                    INSERT INTO management_sessions (id, installation_id, token_digest, token_hash, expires_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """.trimIndent(),
+                ).use { statement ->
+                    statement.setObject(PARAM_1, sessionId)
+                    statement.setObject(PARAM_2, match.installationId)
+                    statement.setBytes(PARAM_3, stored.digest)
+                    statement.setString(PARAM_4, stored.hash)
+                    statement.setInstant(PARAM_5, sessionExpiresAt)
+                    statement.executeUpdate()
+                }
+                connection.commit()
+                IssuedCredential(sessionId, match.installationId, sessionRaw)
+            } catch (exception: Exception) {
+                connection.rollback()
+                throw exception
+            } finally {
+                connection.autoCommit = previousAutoCommit
+            }
+        }
+
+    suspend fun verifyManagementSession(
+        raw: String,
+        now: Instant = Instant.now(),
+    ): ManagementSessionContext? =
+        databaseFactory.dbQuery { connection ->
+            data class Candidate(
+                val id: UUID,
+                val installationId: UUID,
+                val digest: ByteArray,
+                val hash: String,
+            )
+            val candidates = mutableListOf<Candidate>()
+            connection.prepareStatement(
+                """
+                SELECT id, installation_id, token_digest, token_hash
+                FROM management_sessions
+                WHERE expires_at > ? AND token_digest = ?
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setInstant(PARAM_1, now)
+                statement.setBytes(PARAM_2, CredentialCodec.digest(raw))
+                statement.executeQuery().use { result ->
+                    while (result.next()) {
+                        val hash = result.getString("token_hash") ?: continue
+                        candidates += Candidate(
+                            id = result.getObject("id", UUID::class.java),
+                            installationId = result.getObject("installation_id", UUID::class.java),
+                            digest = result.getBytes("token_digest"),
+                            hash = hash,
+                        )
+                    }
+                }
+            }
+            candidates.firstOrNull { CredentialCodec.matches(raw, it.digest, it.hash) }
+                ?.let { ManagementSessionContext(it.id, it.installationId) }
         }
 
     suspend fun cleanupExpiredManagementLinks(now: Instant = Instant.now()): Int =
         databaseFactory.dbQuery { connection ->
             connection.prepareStatement(
                 "DELETE FROM management_links WHERE expires_at <= ?",
+            ).use { statement ->
+                statement.setInstant(PARAM_1, now)
+                statement.executeUpdate()
+            }
+        }
+
+    suspend fun cleanupExpiredManagementSessions(now: Instant = Instant.now()): Int =
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement(
+                "DELETE FROM management_sessions WHERE expires_at <= ?",
             ).use { statement ->
                 statement.setInstant(PARAM_1, now)
                 statement.executeUpdate()

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
@@ -1,0 +1,310 @@
+package net.raquezha.nuecagram.plugins
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import net.raquezha.nuecagram.db.InstallationAdminContext
+import net.raquezha.nuecagram.db.InstallationRepository
+import org.koin.ktor.ext.inject
+
+private const val SESSION_COOKIE_NAME = "nuecagram_manage_session"
+private const val SESSION_TTL_HOURS = 8L
+private const val SESSION_TTL_SECONDS = SESSION_TTL_HOURS * 60L * 60L
+private const val ROTATION_GRACE_MINUTES = 0L
+
+@Suppress("LongMethod")
+fun Route.managementRouting(basePath: String) {
+    val installationRepository by inject<InstallationRepository>()
+
+    get(basePath) {
+        call.respondManagementHtml(
+            title = "Nuecagram setup",
+            body = onboardingHtml(basePath),
+        )
+    }
+
+    get("$basePath/setup") {
+        call.respondManagementHtml(
+            title = "Nuecagram setup",
+            body = onboardingHtml(basePath),
+        )
+    }
+
+    get("$basePath/manage/{token}") {
+        val token = call.parameters["token"]?.trim().orEmpty()
+        if (token.isBlank()) {
+            call.respondManagementHtml(
+                status = HttpStatusCode.NotFound,
+                title = "Link unavailable",
+                body = recoveryHtml(basePath),
+            )
+            return@get
+        }
+        val session =
+            installationRepository.exchangeManagementLinkForSession(
+                raw = token,
+                sessionExpiresAt = managementSessionExpiry(),
+            )
+        if (session == null) {
+            call.respondManagementHtml(
+                status = HttpStatusCode.Gone,
+                title = "Link expired",
+                body = recoveryHtml(basePath),
+            )
+            return@get
+        }
+        call.response.headers.append(
+            HttpHeaders.SetCookie,
+            buildSessionCookie(basePath, session.raw, call.isHttps()),
+        )
+        call.appendSecurityHeaders()
+        call.respondRedirect("$basePath/manage")
+    }
+
+    get("$basePath/manage") {
+        val session = call.managementSession(installationRepository)
+        if (session == null) {
+            call.clearManagementSession(basePath)
+            call.respondManagementHtml(
+                status = HttpStatusCode.Unauthorized,
+                title = "Session required",
+                body = recoveryHtml(basePath),
+            )
+            return@get
+        }
+        val installation = installationRepository.installationAdminContext(session.installationId)
+        if (installation == null) {
+            call.clearManagementSession(basePath)
+            call.respondManagementHtml(
+                status = HttpStatusCode.NotFound,
+                title = "Installation unavailable",
+                body = recoveryHtml(basePath),
+            )
+            return@get
+        }
+        call.respondManagementHtml(
+            title = "Manage installation",
+            body = manageHtml(basePath, installation),
+        )
+    }
+
+    post("$basePath/manage/rotate") {
+        call.receiveParameters()
+        val session = call.managementSession(installationRepository)
+        if (session == null) {
+            call.clearManagementSession(basePath)
+            call.respondManagementHtml(
+                status = HttpStatusCode.Unauthorized,
+                title = "Session required",
+                body = recoveryHtml(basePath),
+            )
+            return@post
+        }
+        val installation = installationRepository.installationAdminContext(session.installationId)
+        if (installation == null) {
+            call.clearManagementSession(basePath)
+            call.respondManagementHtml(
+                status = HttpStatusCode.NotFound,
+                title = "Installation unavailable",
+                body = recoveryHtml(basePath),
+            )
+            return@post
+        }
+        val credential =
+            installationRepository.rotateWebhookSecret(
+                installationId = installation.id,
+                graceUntil = Instant.now().plus(ROTATION_GRACE_MINUTES, ChronoUnit.MINUTES),
+            )
+        installationRepository.writeAuditEvent(
+            installationId = installation.id,
+            actorType = "management_session",
+            actorId = session.sessionId.toString(),
+            action = "management_rotate",
+        )
+        call.respondManagementHtml(
+            title = "Credential rotated",
+            body = rotatedHtml(basePath, installation, credential.raw),
+        )
+    }
+
+    post("$basePath/manage/logout") {
+        call.receiveParameters()
+        call.clearManagementSession(basePath)
+        call.appendSecurityHeaders()
+        call.respondRedirect(basePath)
+    }
+}
+
+private suspend fun ApplicationCall.managementSession(
+    installationRepository: InstallationRepository,
+) =
+    request.cookies[SESSION_COOKIE_NAME]
+        ?.takeIf(String::isNotBlank)
+        ?.let { installationRepository.verifyManagementSession(it) }
+
+private fun ApplicationCall.clearManagementSession(basePath: String) {
+    response.headers.append(HttpHeaders.SetCookie, buildExpiredSessionCookie(basePath, isHttps()))
+}
+
+private suspend fun ApplicationCall.respondManagementHtml(
+    title: String,
+    body: String,
+    status: HttpStatusCode = HttpStatusCode.OK,
+) {
+    appendSecurityHeaders()
+    respondText(
+        managementDocument(title, body),
+        ContentType.Text.Html,
+        status,
+    )
+}
+
+private fun ApplicationCall.appendSecurityHeaders() {
+    response.headers.append("Cache-Control", "no-store")
+    response.headers.append("Pragma", "no-cache")
+    response.headers.append("Referrer-Policy", "no-referrer")
+    response.headers.append("X-Frame-Options", "DENY")
+    response.headers.append("X-Content-Type-Options", "nosniff")
+    response.headers.append(
+        "Content-Security-Policy",
+        "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+    )
+    if (isHttps()) {
+        response.headers.append(
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains",
+        )
+    }
+}
+
+private fun ApplicationCall.isHttps(): Boolean =
+    request.headers["X-Forwarded-Proto"]?.substringBefore(',')?.trim().equals("https", ignoreCase = true)
+
+private fun buildSessionCookie(
+    basePath: String,
+    value: String,
+    secure: Boolean,
+): String =
+    buildString {
+        append(SESSION_COOKIE_NAME)
+        append('=')
+        append(value)
+        append("; Path=")
+        append(basePath)
+        append("/manage; Max-Age=")
+        append(SESSION_TTL_SECONDS)
+        append("; HttpOnly; SameSite=Strict")
+        if (secure) append("; Secure")
+    }
+
+private fun buildExpiredSessionCookie(basePath: String, secure: Boolean): String =
+    buildString {
+        append(SESSION_COOKIE_NAME)
+        append("=; Path=")
+        append(basePath)
+        append("/manage; Max-Age=0; HttpOnly; SameSite=Strict")
+        if (secure) append("; Secure")
+    }
+
+private fun managementSessionExpiry(): Instant = Instant.now().plus(SESSION_TTL_HOURS, ChronoUnit.HOURS)
+
+private fun onboardingHtml(basePath: String): String =
+    """
+    <h1>Nuecagram onboarding</h1>
+    <p>Setup stays in Telegram. Start a private chat with the bot, run <code>/start</code>, then run
+    <code>/setup &lt;gitlab-base-url&gt; &lt;project-id&gt; [topic-id]</code> in your group.</p>
+    <p>Management links redirect into a short-lived session at
+    <code>${(basePath + "/manage").html()}</code>. Credentials are only shown when first issued or rotated.</p>
+    """.trimIndent()
+
+private fun recoveryHtml(basePath: String): String =
+    """
+    <h1>Recovery</h1>
+    <p>This link is missing, expired, or already used.</p>
+    <p>Use Telegram private <code>/start</code>, then run <code>/manage &lt;installation-id&gt;</code>
+    or <code>/rotate &lt;installation-id&gt;</code> in the installation group for a fresh management link.</p>
+    <p><a href="${basePath.html()}">Back to setup</a></p>
+    """.trimIndent()
+
+private fun manageHtml(
+    basePath: String,
+    installation: InstallationAdminContext,
+): String =
+    buildString {
+        append("<h1>Manage installation</h1>")
+        append("<p><strong>Installation:</strong> <code>${installation.id.toString().html()}</code></p>")
+        append("<p><strong>GitLab:</strong> ${installation.gitlabBaseUrl.html()}</p>")
+        installation.gitlabProjectId?.let {
+            append("<p><strong>Project:</strong> $it</p>")
+        }
+        installation.telegramTopicId?.let {
+            append("<p><strong>Topic:</strong> $it</p>")
+        }
+        append("<p><strong>Muted:</strong> ${if (installation.muted) "yes" else "no"}</p>")
+        append("<h2>Rotate credential</h2>")
+        append("<p>The new GitLab credential is shown once, on the next page only.</p>")
+        append(
+            "<form method=\"post\" action=\"${(basePath + "/manage/rotate").html()}\">" +
+                "<button type=\"submit\">Rotate credential</button></form>",
+        )
+        append("<h2>Recovery</h2>")
+        append(
+            "<p>Lost this session? Use private <code>/start</code>, then <code>/manage " +
+                "${installation.id.toString().html()}</code> in the installation group.</p>",
+        )
+        append(
+            "<form method=\"post\" action=\"${(basePath + "/manage/logout").html()}\">" +
+                "<button type=\"submit\">Log out</button></form>",
+        )
+    }
+
+private fun rotatedHtml(
+    basePath: String,
+    installation: InstallationAdminContext,
+    credential: String,
+): String =
+    buildString {
+        append("<h1>Credential rotated</h1>")
+        append("<p><strong>Installation:</strong> <code>${installation.id.toString().html()}</code></p>")
+        append("<p><strong>GitLab credential:</strong> <code>${credential.html()}</code></p>")
+        append("<p>Store it now. This page is the only place the raw credential is shown.</p>")
+        append(
+            "<p><a href=\"${(basePath + "/manage").html()}\">Return to management</a></p>",
+        )
+    }
+
+private fun managementDocument(title: String, body: String): String =
+    """
+    <!doctype html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>${title.html()}</title>
+        <style>
+          body { font-family: sans-serif; margin: 2rem auto; max-width: 48rem; line-height: 1.5; padding: 0 1rem; }
+          code { background: #f4f4f4; padding: 0.1rem 0.3rem; border-radius: 0.2rem; }
+          button { font: inherit; padding: 0.6rem 1rem; }
+          form { margin: 1rem 0; }
+        </style>
+      </head>
+      <body>
+        $body
+      </body>
+    </html>
+    """.trimIndent()
+
+private fun String.html(): String =
+    replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
@@ -4,7 +4,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
@@ -98,7 +97,6 @@ fun Route.managementRouting(basePath: String) {
     }
 
     post("$basePath/manage/rotate") {
-        call.receiveParameters()
         val session = call.managementSession(installationRepository)
         if (session == null) {
             call.clearManagementSession(basePath)
@@ -137,7 +135,6 @@ fun Route.managementRouting(basePath: String) {
     }
 
     post("$basePath/manage/logout") {
-        call.receiveParameters()
         call.clearManagementSession(basePath)
         call.appendSecurityHeaders()
         call.respondRedirect(basePath)

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import net.raquezha.nuecagram.db.DatabaseFactory
+import net.raquezha.nuecagram.db.InstallationRepository
 import net.raquezha.nuecagram.webhook.SkipEventException
 import net.raquezha.nuecagram.webhook.WebHookService
 import net.raquezha.nuecagram.webhook.WebhookRequestException
@@ -29,6 +30,7 @@ private fun Application.healthPath() = basePath() + "/health"
 fun Application.configureRouting() {
     val databaseFactory by inject<DatabaseFactory>()
     val webhookService by inject<WebHookService>()
+    val installationRepository by inject<InstallationRepository>()
     val webhookRequestHandler by inject<WebhookRequestHandler> { parametersOf(this) }
     val logger by inject<KLogger>()
 
@@ -46,6 +48,7 @@ fun Application.configureRouting() {
         }
 
         telegramRouting(this@configureRouting.basePath())
+        managementRouting(this@configureRouting.basePath())
 
         post("/webhook") {
             try {
@@ -90,6 +93,8 @@ fun Application.configureRouting() {
                 delay(CLEANUP_INTERVAL_MS)
                 try {
                     webhookService.cleanupStaleEntries()
+                    installationRepository.cleanupExpiredManagementLinks()
+                    installationRepository.cleanupExpiredManagementSessions()
                     logger.debug { "Periodic cleanup completed" }
                 } catch (e: Exception) {
                     logger.error(e) { "Periodic cleanup failed: ${e.message}" }

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/TelegramRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/TelegramRouting.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.Route
 import java.security.MessageDigest
 import kotlinx.serialization.json.Json
 import net.raquezha.nuecagram.ConfigWithSecrets
+import net.raquezha.nuecagram.configuredBasePath
 import net.raquezha.nuecagram.telegram.TelegramUpdate
 import net.raquezha.nuecagram.telegram.TelegramUpdateHandler
 import org.koin.ktor.ext.inject
@@ -51,7 +52,4 @@ fun Route.telegramRouting(basePath: String) {
     }
 }
 
-fun Application.basePath(): String =
-    (System.getenv("NUECAGRAM_BASE_PATH")?.trim()?.removeSuffix("/") ?: "/nuecagram").also {
-        require(it.startsWith('/')) { "NUECAGRAM_BASE_PATH must start with '/'" }
-    }
+fun Application.basePath(): String = configuredBasePath()

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
@@ -6,6 +6,7 @@ import java.util.UUID
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.raquezha.nuecagram.ConfigWithSecrets
+import net.raquezha.nuecagram.configuredBasePath
 import net.raquezha.nuecagram.db.InstallationAdminContext
 import net.raquezha.nuecagram.db.InstallationRecord
 import net.raquezha.nuecagram.db.InstallationRepository
@@ -338,7 +339,8 @@ private fun ConfigWithSecrets.publicBaseUrl(): String {
 
 private fun ConfigWithSecrets.webhookUrl(): String = "${publicBaseUrl()}/webhook"
 
-private fun ConfigWithSecrets.managementUrl(code: String): String = "${publicBaseUrl()}/nuecagram/manage/$code"
+private fun ConfigWithSecrets.managementUrl(code: String): String =
+    "${publicBaseUrl()}${configuredBasePath()}/manage/$code"
 
 private fun setupDetailsText(
     config: ConfigWithSecrets,

--- a/src/main/resources/db/migration/V4__management_sessions.sql
+++ b/src/main/resources/db/migration/V4__management_sessions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE management_sessions (
+    id UUID PRIMARY KEY,
+    installation_id UUID NOT NULL REFERENCES installations (id) ON DELETE CASCADE,
+    token_digest BYTEA NOT NULL UNIQUE,
+    token_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX management_sessions_expiry
+    ON management_sessions (expires_at);

--- a/src/test/kotlin/net/raquezha/nuecagram/InstallationRepositoryTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/InstallationRepositoryTest.kt
@@ -69,6 +69,26 @@ val InstallationRepositoryTests by testSuite {
             assertThat(successes).hasSize(1)
             assertThat(successes.single().installationId).isEqualTo(installation.id)
             assertThat(repository.consumeManagementLink(link.raw)).isNull()
+
+            val sessionLink =
+                repository.issueManagementLink(
+                    installation.id,
+                    Instant.now().plus(30, ChronoUnit.MINUTES),
+                )
+            val session = repository.exchangeManagementLinkForSession(
+                sessionLink.raw,
+                Instant.now().plus(8, ChronoUnit.HOURS),
+            )
+            assertThat(session).isNotNull()
+            assertThat(
+                repository.verifyManagementSession(session!!.raw)?.installationId,
+            ).isEqualTo(installation.id)
+            assertThat(
+                repository.exchangeManagementLinkForSession(
+                    sessionLink.raw,
+                    Instant.now().plus(8, ChronoUnit.HOURS),
+                ),
+            ).isNull()
         } finally {
             DatabaseFactory.close()
         }
@@ -97,7 +117,18 @@ val InstallationRepositoryTests by testSuite {
             assertThat(repository.verifyWebhookSecret(original.raw)).isNull()
             assertThat(repository.verifyWebhookSecret(rotated.raw)?.secretId).isEqualTo(rotated.id)
             assertThat(repository.confirmWebhookSecret(rotated.id)).isTrue()
+            val expiredSessionLink =
+                repository.issueManagementLink(
+                    installation.id,
+                    Instant.now().plus(30, ChronoUnit.MINUTES),
+                )
+            val session = repository.exchangeManagementLinkForSession(
+                expiredSessionLink.raw,
+                Instant.now().minus(1, ChronoUnit.MINUTES),
+            )
+            assertThat(session).isNotNull()
             assertThat(repository.cleanupExpiredManagementLinks()).isEqualTo(1)
+            assertThat(repository.cleanupExpiredManagementSessions()).isEqualTo(1)
             assertThat(repository.cleanupExpiredWebhookSecrets()).isEqualTo(1)
 
             repository.writeAuditEvent(

--- a/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
@@ -1,0 +1,153 @@
+package net.raquezha.nuecagram
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class ManagementUiTest : BaseEventTestHelper() {
+    @Test
+    fun managementLinkExchangesIntoTokenFreeSession() =
+        testApplication {
+            configureTestApplication()
+            val link = runBlocking {
+                installationRepository.issueManagementLink(
+                    installation.id,
+                    Instant.now().plus(30, ChronoUnit.MINUTES),
+                ).raw
+            }
+            val client = client.config { followRedirects = false }
+
+            val response =
+                client.get("/nuecagram/manage/$link") {
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.Found)
+            assertThat(response.headers[HttpHeaders.Location]).isEqualTo("/nuecagram/manage")
+            assertThat(response.headers[HttpHeaders.Location]).doesNotContain(link)
+            val setCookie = response.headers[HttpHeaders.SetCookie].orEmpty()
+            assertThat(setCookie).contains("nuecagram_manage_session=")
+            assertThat(setCookie).contains("HttpOnly")
+            assertThat(setCookie).contains("Secure")
+            assertThat(setCookie).contains("SameSite=Strict")
+            assertThat(setCookie).contains("Path=/nuecagram/manage")
+
+            val session = setCookie.substringAfter("nuecagram_manage_session=").substringBefore(';')
+            val page =
+                client.get("/nuecagram/manage") {
+                    header(HttpHeaders.Cookie, "nuecagram_manage_session=$session")
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(page.status).isEqualTo(HttpStatusCode.OK)
+            assertThat(page.bodyAsText()).contains(installation.id.toString())
+            assertThat(page.bodyAsText()).doesNotContain(link)
+        }
+
+    @Test
+    fun managementPageAddsSecurityHeadersAndRecoveryGuidance() =
+        testApplication {
+            configureTestApplication()
+            val session = exchangeSessionCookie(client.config { followRedirects = false })
+
+            val response =
+                client.get("/nuecagram/manage") {
+                    header(HttpHeaders.Cookie, session)
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+            assertThat(response.headers["Content-Security-Policy"]).contains("default-src 'none'")
+            assertThat(response.headers["Referrer-Policy"]).isEqualTo("no-referrer")
+            assertThat(response.headers["X-Frame-Options"]).isEqualTo("DENY")
+            assertThat(response.headers["X-Content-Type-Options"]).isEqualTo("nosniff")
+            assertThat(
+                response.headers["Strict-Transport-Security"],
+            ).isEqualTo("max-age=31536000; includeSubDomains")
+            assertThat(response.bodyAsText()).contains("Recovery")
+            assertThat(response.bodyAsText()).contains("/manage ${installation.id}")
+        }
+
+    @Test
+    fun rotateRevealsCredentialOnceAndKeepsManagePageCredentialFree() =
+        testApplication {
+            configureTestApplication()
+            val oldCredential = runBlocking { installationRepository.issueWebhookSecret(installation.id).raw }
+            val session = exchangeSessionCookie(client.config { followRedirects = false })
+
+            val rotate =
+                client.post("/nuecagram/manage/rotate") {
+                    header(HttpHeaders.Cookie, session)
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(rotate.status).isEqualTo(HttpStatusCode.OK)
+            val rotateBody = rotate.bodyAsText()
+            assertThat(rotateBody).contains("GitLab credential:")
+            val rotatedCredential =
+                rotateBody.substringAfter("GitLab credential:</strong> <code>").substringBefore("</code>")
+            assertThat(rotatedCredential).isNotEqualTo(oldCredential)
+            assertThat(runBlocking { installationRepository.verifyWebhookSecret(oldCredential) }).isNull()
+            assertThat(runBlocking { installationRepository.verifyWebhookSecret(rotatedCredential) }).isNotNull()
+
+            val page =
+                client.get("/nuecagram/manage") {
+                    header(HttpHeaders.Cookie, session)
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(page.status).isEqualTo(HttpStatusCode.OK)
+            assertThat(page.bodyAsText()).doesNotContain(rotatedCredential)
+            assertThat(page.bodyAsText()).contains("Rotate credential")
+        }
+
+    @Test
+    fun setupPageUsesConfiguredBasePath() {
+        val previous = System.getProperty("nuecagram.basePath")
+        System.setProperty("nuecagram.basePath", "/managed")
+        try {
+            testApplication {
+                configureTestApplication()
+                assertThat(client.get("/managed/setup").status).isEqualTo(HttpStatusCode.OK)
+                assertThat(client.get("/nuecagram/setup").status).isEqualTo(HttpStatusCode.NotFound)
+            }
+        } finally {
+            if (previous == null) {
+                System.clearProperty("nuecagram.basePath")
+            } else {
+                System.setProperty("nuecagram.basePath", previous)
+            }
+        }
+    }
+
+    private fun ApplicationTestBuilder.exchangeSessionCookie(
+        noRedirectClient: io.ktor.client.HttpClient,
+    ): String {
+        val link = runBlocking {
+            installationRepository.issueManagementLink(
+                installation.id,
+                Instant.now().plus(30, ChronoUnit.MINUTES),
+            ).raw
+        }
+        val response =
+            runBlocking {
+                noRedirectClient.get("/nuecagram/manage/$link") {
+                    header("X-Forwarded-Proto", "https")
+                }
+            }
+        val session = response.headers[HttpHeaders.SetCookie].orEmpty()
+            .substringAfter("nuecagram_manage_session=")
+            .substringBefore(';')
+        return "nuecagram_manage_session=$session"
+    }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
@@ -67,6 +67,43 @@ class ManagementUiTest : BaseEventTestHelper() {
         }
 
     @Test
+    fun expiredManagementLinkShowsRecoveryWithoutSessionCookie() =
+        testApplication {
+            configureTestApplication()
+            val expiredLink = runBlocking {
+                installationRepository.issueManagementLink(
+                    installation.id,
+                    Instant.now().minus(1, ChronoUnit.MINUTES),
+                ).raw
+            }
+
+            val response = client.get("${basePath()}/manage/$expiredLink")
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.Gone)
+            assertThat(response.bodyAsText()).contains("Recovery")
+            assertThat(response.headers[HttpHeaders.SetCookie]).isNull()
+        }
+
+    @Test
+    fun manageRequiresValidSessionAndClearsCookie() =
+        testApplication {
+            configureTestApplication()
+
+            val response =
+                client.get("${basePath()}/manage") {
+                    header(HttpHeaders.Cookie, "nuecagram_manage_session=invalid")
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+            assertThat(response.bodyAsText()).contains("Recovery")
+            val setCookie = response.headers[HttpHeaders.SetCookie].orEmpty()
+            assertThat(setCookie).contains("Max-Age=0")
+            assertThat(setCookie).contains("HttpOnly")
+            assertThat(setCookie).contains("Secure")
+        }
+
+    @Test
     fun managementPageAddsSecurityHeadersAndRecoveryGuidance() =
         testApplication {
             configureTestApplication()
@@ -121,6 +158,45 @@ class ManagementUiTest : BaseEventTestHelper() {
             assertThat(page.status).isEqualTo(HttpStatusCode.OK)
             assertThat(page.bodyAsText()).doesNotContain(rotatedCredential)
             assertThat(page.bodyAsText()).contains("Rotate credential")
+        }
+
+    @Test
+    fun httpManagementSessionOmitsSecureAndHsts() =
+        testApplication {
+            configureTestApplication()
+            val link = runBlocking {
+                installationRepository.issueManagementLink(
+                    installation.id,
+                    Instant.now().plus(30, ChronoUnit.MINUTES),
+                ).raw
+            }
+            val noRedirectClient = client.config { followRedirects = false }
+
+            val response = noRedirectClient.get("${basePath()}/manage/$link")
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.Found)
+            assertThat(response.headers[HttpHeaders.SetCookie].orEmpty()).doesNotContain("Secure")
+            assertThat(response.headers["Strict-Transport-Security"]).isNull()
+        }
+
+    @Test
+    fun logoutClearsSessionAndRedirectsToSetup() =
+        testApplication {
+            configureTestApplication()
+            val session = exchangeSessionCookie(client.config { followRedirects = false })
+            val noRedirectClient = client.config { followRedirects = false }
+
+            val response =
+                noRedirectClient.post("${basePath()}/manage/logout") {
+                    header(HttpHeaders.Cookie, session)
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.Found)
+            assertThat(response.headers[HttpHeaders.Location]).isEqualTo(basePath())
+            val setCookie = response.headers[HttpHeaders.SetCookie].orEmpty()
+            assertThat(setCookie).contains("Max-Age=0")
+            assertThat(setCookie).contains("Secure")
         }
 
     @Test

--- a/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
@@ -12,9 +12,21 @@ import io.ktor.server.testing.testApplication
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 class ManagementUiTest : BaseEventTestHelper() {
+    @Before
+    fun resetBasePath() {
+        System.clearProperty("nuecagram.basePath")
+    }
+
+    @After
+    fun clearBasePath() {
+        System.clearProperty("nuecagram.basePath")
+    }
+
     @Test
     fun managementLinkExchangesIntoTokenFreeSession() =
         testApplication {
@@ -28,23 +40,23 @@ class ManagementUiTest : BaseEventTestHelper() {
             val client = client.config { followRedirects = false }
 
             val response =
-                client.get("/nuecagram/manage/$link") {
+                client.get("${basePath()}/manage/$link") {
                     header("X-Forwarded-Proto", "https")
                 }
 
             assertThat(response.status).isEqualTo(HttpStatusCode.Found)
-            assertThat(response.headers[HttpHeaders.Location]).isEqualTo("/nuecagram/manage")
+            assertThat(response.headers[HttpHeaders.Location]).isEqualTo("${basePath()}/manage")
             assertThat(response.headers[HttpHeaders.Location]).doesNotContain(link)
             val setCookie = response.headers[HttpHeaders.SetCookie].orEmpty()
             assertThat(setCookie).contains("nuecagram_manage_session=")
             assertThat(setCookie).contains("HttpOnly")
             assertThat(setCookie).contains("Secure")
             assertThat(setCookie).contains("SameSite=Strict")
-            assertThat(setCookie).contains("Path=/nuecagram/manage")
+            assertThat(setCookie).contains("Path=${basePath()}/manage")
 
             val session = setCookie.substringAfter("nuecagram_manage_session=").substringBefore(';')
             val page =
-                client.get("/nuecagram/manage") {
+                client.get("${basePath()}/manage") {
                     header(HttpHeaders.Cookie, "nuecagram_manage_session=$session")
                     header("X-Forwarded-Proto", "https")
                 }
@@ -61,7 +73,7 @@ class ManagementUiTest : BaseEventTestHelper() {
             val session = exchangeSessionCookie(client.config { followRedirects = false })
 
             val response =
-                client.get("/nuecagram/manage") {
+                client.get("${basePath()}/manage") {
                     header(HttpHeaders.Cookie, session)
                     header("X-Forwarded-Proto", "https")
                 }
@@ -86,7 +98,7 @@ class ManagementUiTest : BaseEventTestHelper() {
             val session = exchangeSessionCookie(client.config { followRedirects = false })
 
             val rotate =
-                client.post("/nuecagram/manage/rotate") {
+                client.post("${basePath()}/manage/rotate") {
                     header(HttpHeaders.Cookie, session)
                     header("X-Forwarded-Proto", "https")
                 }
@@ -101,7 +113,7 @@ class ManagementUiTest : BaseEventTestHelper() {
             assertThat(runBlocking { installationRepository.verifyWebhookSecret(rotatedCredential) }).isNotNull()
 
             val page =
-                client.get("/nuecagram/manage") {
+                client.get("${basePath()}/manage") {
                     header(HttpHeaders.Cookie, session)
                     header("X-Forwarded-Proto", "https")
                 }
@@ -118,7 +130,7 @@ class ManagementUiTest : BaseEventTestHelper() {
         try {
             testApplication {
                 configureTestApplication()
-                assertThat(client.get("/managed/setup").status).isEqualTo(HttpStatusCode.OK)
+                assertThat(client.get("${basePath()}/setup").status).isEqualTo(HttpStatusCode.OK)
                 assertThat(client.get("/nuecagram/setup").status).isEqualTo(HttpStatusCode.NotFound)
             }
         } finally {
@@ -141,7 +153,7 @@ class ManagementUiTest : BaseEventTestHelper() {
         }
         val response =
             runBlocking {
-                noRedirectClient.get("/nuecagram/manage/$link") {
+                noRedirectClient.get("${basePath()}/manage/$link") {
                     header("X-Forwarded-Proto", "https")
                 }
             }
@@ -150,4 +162,6 @@ class ManagementUiTest : BaseEventTestHelper() {
             .substringBefore(';')
         return "nuecagram_manage_session=$session"
     }
+
+    private fun basePath(): String = configuredBasePath()
 }


### PR DESCRIPTION
## Summary
- add server-rendered onboarding and management routes under the configured base path
- exchange one-time management links for hashed server-side sessions, then redirect to a token-free URL
- add rotation/session tests and a Flyway migration for persisted management sessions

## Scope
- `src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt`, routing/base-path helpers, and Telegram management-link URL generation
- `InstallationRepository` session exchange/verification/cleanup and `V4__management_sessions.sql`
- focused repository and management UI coverage

## Verification
- [x] `./gradlew test --tests "net.raquezha.nuecagram.ManagementUiTest" --tests "net.raquezha.nuecagram.InstallationRepositoryTest" --tests "net.raquezha.nuecagram.ApplicationTest"`
- [x] `./gradlew lintKotlinMain lintKotlinTest detekt test build`
- [ ] Manual browser check against a real HTTPS reverse proxy is still needed.

## Risk / Rollback
- Risk: management access now depends on the new `management_sessions` table and cookie handling; regressions would block browser management until fixed.
- Rollback: revert commit `c9cc5ec` and redeploy to restore Telegram-only management-link behavior.

## RPIV Task
- Task: `github:49`
- Slice: S5 — Server-rendered setup and management
- Branch: `feat/github-49-s5-management-ui`

## Human Review Checklist
- [x] Review changed files for repo conventions.
- [x] Confirm verification evidence is sufficient.
- [x] Confirm no secrets, local-only paths, or scratch artifacts are included.
