### PR TITLE
feat: add platform administration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 /local.properties
 
 node_modules/
+
+# RepoScry local cache
+.reposcry/

--- a/src/main/kotlin/net/raquezha/nuecagram/Application.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/Application.kt
@@ -31,13 +31,15 @@ fun main() {
 
 private fun validateRequiredEnvironmentVariables() {
     if (System.getenv("TELEGRAM_BOT_TOKEN").isNullOrBlank() ||
-        System.getenv("TELEGRAM_WEBHOOK_SECRET").isNullOrBlank()
+        System.getenv("TELEGRAM_WEBHOOK_SECRET").isNullOrBlank() ||
+        System.getenv("PLATFORM_ADMIN_PASSWORD_HASH").isNullOrBlank()
     ) {
         throw IllegalStateException(
             """
             Missing required environment variables:
               - TELEGRAM_BOT_TOKEN
               - TELEGRAM_WEBHOOK_SECRET
+              - PLATFORM_ADMIN_PASSWORD_HASH
 
             Please set these variables before starting the application.
             """.trimIndent(),
@@ -56,6 +58,7 @@ fun configWithSecrets(
     filename: String,
     botApi: String,
     telegramWebhookSecret: String,
+    platformAdminHash: String,
 ): ConfigWithSecrets {
     val config = config(filename)
 
@@ -65,6 +68,7 @@ fun configWithSecrets(
         host = config.host,
         port = config.port,
         botApi = botApi,
+        platformAdminHash = platformAdminHash,
         telegramWebhookSecret = telegramWebhookSecret,
     )
 }

--- a/src/main/kotlin/net/raquezha/nuecagram/ConfigWithSecrets.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/ConfigWithSecrets.kt
@@ -7,4 +7,5 @@ data class ConfigWithSecrets(
     val port: Int,
     val botApi: String,
     val telegramWebhookSecret: String,
+    val platformAdminHash: String,
 )

--- a/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
@@ -3,6 +3,7 @@ package net.raquezha.nuecagram.db
 import java.sql.PreparedStatement
 import java.sql.Types
 import java.time.Instant
+import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.UUID
 import net.raquezha.nuecagram.webhook.ChatDetails
@@ -13,6 +14,7 @@ private const val PARAM_3 = 3
 private const val PARAM_4 = 4
 private const val PARAM_5 = 5
 private const val PARAM_6 = 6
+private const val PARAM_7 = 7
 
 data class InstallationRecord(
     val id: UUID,
@@ -38,9 +40,36 @@ data class ConsumedManagementLink(
     val installationId: UUID,
 )
 
+data class IssuedManagementSession(
+    val sessionId: UUID,
+    val installationId: UUID,
+    val raw: String,
+    val csrf: String,
+)
+
 data class ManagementSessionContext(
     val sessionId: UUID,
     val installationId: UUID,
+    val csrfDigest: ByteArray?,
+    val csrfHash: String?,
+)
+
+data class IssuedPlatformAdminSession(
+    val id: UUID,
+    val raw: String,
+    val csrf: String,
+)
+
+data class PlatformAdminSessionContext(
+    val id: UUID,
+    val csrfDigest: ByteArray,
+    val csrfHash: String,
+)
+
+data class PlatformAdminAuditRecord(
+    val installationId: UUID?,
+    val action: String,
+    val createdAt: Instant,
 )
 
 data class InstallationContext(
@@ -372,7 +401,7 @@ class InstallationRepository(
         raw: String,
         sessionExpiresAt: Instant,
         now: Instant = Instant.now(),
-    ): IssuedCredential? =
+    ): IssuedManagementSession? =
         databaseFactory.dbQuery { connection ->
             data class Candidate(
                 val id: UUID,
@@ -407,6 +436,7 @@ class InstallationRepository(
                     ?: return@dbQuery null
             val sessionId = UUID.randomUUID()
             val (sessionRaw, stored) = CredentialCodec.issueCredential()
+            val (csrf, storedCsrf) = CredentialCodec.issueCredential()
             val previousAutoCommit = connection.autoCommit
             connection.autoCommit = false
             try {
@@ -429,8 +459,9 @@ class InstallationRepository(
                 }
                 connection.prepareStatement(
                     """
-                    INSERT INTO management_sessions (id, installation_id, token_digest, token_hash, expires_at)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO management_sessions
+                        (id, installation_id, token_digest, token_hash, expires_at, csrf_digest, csrf_hash)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                     """.trimIndent(),
                 ).use { statement ->
                     statement.setObject(PARAM_1, sessionId)
@@ -438,10 +469,12 @@ class InstallationRepository(
                     statement.setBytes(PARAM_3, stored.digest)
                     statement.setString(PARAM_4, stored.hash)
                     statement.setInstant(PARAM_5, sessionExpiresAt)
+                    statement.setBytes(PARAM_6, storedCsrf.digest)
+                    statement.setString(PARAM_7, storedCsrf.hash)
                     statement.executeUpdate()
                 }
                 connection.commit()
-                IssuedCredential(sessionId, match.installationId, sessionRaw)
+                IssuedManagementSession(sessionId, match.installationId, sessionRaw, csrf)
             } catch (exception: Exception) {
                 connection.rollback()
                 throw exception
@@ -455,16 +488,9 @@ class InstallationRepository(
         now: Instant = Instant.now(),
     ): ManagementSessionContext? =
         databaseFactory.dbQuery { connection ->
-            data class Candidate(
-                val id: UUID,
-                val installationId: UUID,
-                val digest: ByteArray,
-                val hash: String,
-            )
-            val candidates = mutableListOf<Candidate>()
             connection.prepareStatement(
                 """
-                SELECT id, installation_id, token_digest, token_hash
+                SELECT id, installation_id, token_digest, token_hash, csrf_digest, csrf_hash
                 FROM management_sessions
                 WHERE expires_at > ? AND token_digest = ?
                 """.trimIndent(),
@@ -474,17 +500,163 @@ class InstallationRepository(
                 statement.executeQuery().use { result ->
                     while (result.next()) {
                         val hash = result.getString("token_hash") ?: continue
-                        candidates += Candidate(
-                            id = result.getObject("id", UUID::class.java),
-                            installationId = result.getObject("installation_id", UUID::class.java),
-                            digest = result.getBytes("token_digest"),
-                            hash = hash,
-                        )
+                        if (CredentialCodec.matches(raw, result.getBytes("token_digest"), hash)) {
+                            return@dbQuery ManagementSessionContext(
+                                sessionId = result.getObject("id", UUID::class.java),
+                                installationId = result.getObject("installation_id", UUID::class.java),
+                                csrfDigest = result.getBytes("csrf_digest"),
+                                csrfHash = result.getString("csrf_hash"),
+                            )
+                        }
+                    }
+                    null
+                }
+            }
+        }
+
+    fun verifyManagementCsrf(
+        session: ManagementSessionContext,
+        raw: String,
+    ): Boolean =
+        session.csrfDigest?.let { digest ->
+            session.csrfHash?.let { hash -> CredentialCodec.matches(raw, digest, hash) }
+        } ?: false
+
+    suspend fun deleteManagementSession(id: UUID): Boolean =
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement("DELETE FROM management_sessions WHERE id = ?").use { statement ->
+                statement.setObject(PARAM_1, id)
+                statement.executeUpdate() == 1
+            }
+        }
+
+    suspend fun issuePlatformAdminSession(expiresAt: Instant): IssuedPlatformAdminSession {
+        val id = UUID.randomUUID()
+        val (raw, token) = CredentialCodec.issueCredential()
+        val (csrf, storedCsrf) = CredentialCodec.issueCredential()
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement(
+                """
+                INSERT INTO platform_admin_sessions
+                    (id, token_digest, token_hash, csrf_digest, csrf_hash, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setObject(PARAM_1, id)
+                statement.setBytes(PARAM_2, token.digest)
+                statement.setString(PARAM_3, token.hash)
+                statement.setBytes(PARAM_4, storedCsrf.digest)
+                statement.setString(PARAM_5, storedCsrf.hash)
+                statement.setInstant(PARAM_6, expiresAt)
+                statement.executeUpdate()
+            }
+        }
+        return IssuedPlatformAdminSession(id, raw, csrf)
+    }
+
+    suspend fun verifyPlatformAdminSession(
+        raw: String,
+        now: Instant = Instant.now(),
+    ): PlatformAdminSessionContext? =
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement(
+                """
+                SELECT id, token_digest, token_hash, csrf_digest, csrf_hash
+                FROM platform_admin_sessions
+                WHERE expires_at > ? AND token_digest = ?
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setInstant(PARAM_1, now)
+                statement.setBytes(PARAM_2, CredentialCodec.digest(raw))
+                statement.executeQuery().use { result ->
+                    while (result.next()) {
+                        if (
+                            CredentialCodec.matches(
+                                raw,
+                                result.getBytes("token_digest"),
+                                result.getString("token_hash"),
+                            )
+                        ) {
+                            return@dbQuery PlatformAdminSessionContext(
+                                id = result.getObject("id", UUID::class.java),
+                                csrfDigest = result.getBytes("csrf_digest"),
+                                csrfHash = result.getString("csrf_hash"),
+                            )
+                        }
+                    }
+                    null
+                }
+            }
+        }
+
+    fun verifyPlatformAdminCsrf(
+        session: PlatformAdminSessionContext,
+        raw: String,
+    ): Boolean = CredentialCodec.matches(raw, session.csrfDigest, session.csrfHash)
+
+    suspend fun deletePlatformAdminSession(id: UUID): Boolean =
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement("DELETE FROM platform_admin_sessions WHERE id = ?").use { statement ->
+                statement.setObject(PARAM_1, id)
+                statement.executeUpdate() == 1
+            }
+        }
+
+    suspend fun platformAdminInstallations(): List<InstallationAdminContext> =
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement(
+                """
+                SELECT i.id, i.gitlab_base_url, i.gitlab_project_id, i.telegram_chat_id, i.telegram_topic_id,
+                    COALESCE(m.muted, FALSE) AS muted
+                FROM installations i
+                LEFT JOIN mute_states m ON m.installation_id = i.id
+                ORDER BY i.created_at DESC
+                """.trimIndent(),
+            ).use { statement ->
+                statement.executeQuery().use { result ->
+                    buildList {
+                        while (result.next()) {
+                            add(
+                                InstallationAdminContext(
+                                    id = result.getObject("id", UUID::class.java),
+                                    gitlabBaseUrl = result.getString("gitlab_base_url"),
+                                    gitlabProjectId = result.getNullableLong("gitlab_project_id"),
+                                    telegramChatId = result.getLong("telegram_chat_id"),
+                                    telegramTopicId = result.getNullableLong("telegram_topic_id"),
+                                    muted = result.getBoolean("muted"),
+                                ),
+                            )
+                        }
                     }
                 }
             }
-            candidates.firstOrNull { CredentialCodec.matches(raw, it.digest, it.hash) }
-                ?.let { ManagementSessionContext(it.id, it.installationId) }
+        }
+
+    suspend fun platformAdminAuditEvents(limit: Int = 200): List<PlatformAdminAuditRecord> =
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement(
+                """
+                SELECT installation_id, action, created_at
+                FROM audit_events
+                ORDER BY created_at DESC
+                LIMIT ?
+                """.trimIndent(),
+            ).use { statement ->
+                statement.setInt(PARAM_1, limit)
+                statement.executeQuery().use { result ->
+                    buildList {
+                        while (result.next()) {
+                            add(
+                                PlatformAdminAuditRecord(
+                                    installationId = result.getObject("installation_id", UUID::class.java),
+                                    action = result.getString("action"),
+                                    createdAt = result.getObject("created_at", OffsetDateTime::class.java).toInstant(),
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
         }
 
     suspend fun cleanupExpiredManagementLinks(now: Instant = Instant.now()): Int =
@@ -501,6 +673,16 @@ class InstallationRepository(
         databaseFactory.dbQuery { connection ->
             connection.prepareStatement(
                 "DELETE FROM management_sessions WHERE expires_at <= ?",
+            ).use { statement ->
+                statement.setInstant(PARAM_1, now)
+                statement.executeUpdate()
+            }
+        }
+
+    suspend fun cleanupExpiredPlatformAdminSessions(now: Instant = Instant.now()): Int =
+        databaseFactory.dbQuery { connection ->
+            connection.prepareStatement(
+                "DELETE FROM platform_admin_sessions WHERE expires_at <= ?",
             ).use { statement ->
                 statement.setInstant(PARAM_1, now)
                 statement.executeUpdate()

--- a/src/main/kotlin/net/raquezha/nuecagram/di/Module.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/di/Module.kt
@@ -28,6 +28,7 @@ import net.raquezha.nuecagram.webhook.WebHookService
 import net.raquezha.nuecagram.webhook.WebhookMessageFormatter
 import net.raquezha.nuecagram.webhook.WebhookRequestHandler
 import org.koin.dsl.module
+import org.mindrot.jbcrypt.BCrypt
 
 fun appModule() =
     listOf(
@@ -64,6 +65,7 @@ val testModule =
                 host = "localhost",
                 port = 8080,
                 botApi = "mock_bot_api",
+                platformAdminHash = BCrypt.hashpw("test-admin-password", BCrypt.gensalt(4)),
                 telegramWebhookSecret = "test-telegram-webhook-token",
             )
         }
@@ -75,6 +77,8 @@ val provideConfigModule =
             filename = "/application.json",
             botApi = System.getenv("TELEGRAM_BOT_TOKEN")
                 ?: throw IllegalStateException("TELEGRAM_BOT_TOKEN missing"),
+            platformAdminHash = System.getenv("PLATFORM_ADMIN_PASSWORD_HASH")
+                ?: throw IllegalStateException("PLATFORM_ADMIN_PASSWORD_HASH missing"),
             telegramWebhookSecret = System.getenv("TELEGRAM_WEBHOOK_SECRET")
                 ?: throw IllegalStateException("TELEGRAM_WEBHOOK_SECRET missing"),
         ) }

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
@@ -4,6 +4,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
@@ -16,6 +17,7 @@ import net.raquezha.nuecagram.db.InstallationRepository
 import org.koin.ktor.ext.inject
 
 private const val SESSION_COOKIE_NAME = "nuecagram_manage_session"
+private const val CSRF_COOKIE_NAME = "nuecagram_manage_csrf"
 private const val SESSION_TTL_HOURS = 8L
 private const val SESSION_TTL_SECONDS = SESSION_TTL_HOURS * 60L * 60L
 private const val ROTATION_GRACE_MINUTES = 0L
@@ -65,6 +67,10 @@ fun Route.managementRouting(basePath: String) {
             HttpHeaders.SetCookie,
             buildSessionCookie(basePath, session.raw, call.isHttps()),
         )
+        call.response.headers.append(
+            HttpHeaders.SetCookie,
+            buildCsrfCookie(basePath, session.csrf, call.isHttps()),
+        )
         call.appendSecurityHeaders()
         call.respondRedirect("$basePath/manage")
     }
@@ -72,6 +78,16 @@ fun Route.managementRouting(basePath: String) {
     get("$basePath/manage") {
         val session = call.managementSession(installationRepository)
         if (session == null) {
+            call.clearManagementSession(basePath)
+            call.respondManagementHtml(
+                status = HttpStatusCode.Unauthorized,
+                title = "Session required",
+                body = recoveryHtml(basePath),
+            )
+            return@get
+        }
+        val csrf = call.request.cookies[CSRF_COOKIE_NAME].orEmpty()
+        if (!installationRepository.verifyManagementCsrf(session, csrf)) {
             call.clearManagementSession(basePath)
             call.respondManagementHtml(
                 status = HttpStatusCode.Unauthorized,
@@ -92,7 +108,7 @@ fun Route.managementRouting(basePath: String) {
         }
         call.respondManagementHtml(
             title = "Manage installation",
-            body = manageHtml(basePath, installation),
+            body = manageHtml(basePath, installation, csrf),
         )
     }
 
@@ -104,6 +120,15 @@ fun Route.managementRouting(basePath: String) {
                 status = HttpStatusCode.Unauthorized,
                 title = "Session required",
                 body = recoveryHtml(basePath),
+            )
+            return@post
+        }
+        val csrf = call.receiveParameters()["csrf"].orEmpty()
+        if (!installationRepository.verifyManagementCsrf(session, csrf)) {
+            call.respondManagementHtml(
+                status = HttpStatusCode.Forbidden,
+                title = "Request rejected",
+                body = "<h1>Request rejected</h1><p>The CSRF token is invalid.</p>",
             )
             return@post
         }
@@ -135,6 +160,17 @@ fun Route.managementRouting(basePath: String) {
     }
 
     post("$basePath/manage/logout") {
+        val session = call.managementSession(installationRepository)
+        val csrf = call.receiveParameters()["csrf"].orEmpty()
+        if (session == null || !installationRepository.verifyManagementCsrf(session, csrf)) {
+            call.respondManagementHtml(
+                status = HttpStatusCode.Forbidden,
+                title = "Request rejected",
+                body = "<h1>Request rejected</h1><p>The session or CSRF token is invalid.</p>",
+            )
+            return@post
+        }
+        installationRepository.deleteManagementSession(session.sessionId)
         call.clearManagementSession(basePath)
         call.appendSecurityHeaders()
         call.respondRedirect(basePath)
@@ -150,9 +186,10 @@ private suspend fun ApplicationCall.managementSession(
 
 private fun ApplicationCall.clearManagementSession(basePath: String) {
     response.headers.append(HttpHeaders.SetCookie, buildExpiredSessionCookie(basePath, isHttps()))
+    response.headers.append(HttpHeaders.SetCookie, buildExpiredCsrfCookie(basePath, isHttps()))
 }
 
-private suspend fun ApplicationCall.respondManagementHtml(
+internal suspend fun ApplicationCall.respondManagementHtml(
     title: String,
     body: String,
     status: HttpStatusCode = HttpStatusCode.OK,
@@ -165,7 +202,7 @@ private suspend fun ApplicationCall.respondManagementHtml(
     )
 }
 
-private fun ApplicationCall.appendSecurityHeaders() {
+internal fun ApplicationCall.appendSecurityHeaders() {
     response.headers.append("Cache-Control", "no-store")
     response.headers.append("Pragma", "no-cache")
     response.headers.append("Referrer-Policy", "no-referrer")
@@ -183,7 +220,7 @@ private fun ApplicationCall.appendSecurityHeaders() {
     }
 }
 
-private fun ApplicationCall.isHttps(): Boolean =
+internal fun ApplicationCall.isHttps(): Boolean =
     request.headers["X-Forwarded-Proto"]?.substringBefore(',')?.trim().equals("https", ignoreCase = true)
 
 private fun buildSessionCookie(
@@ -200,6 +237,27 @@ private fun buildSessionCookie(
         append("/manage; Max-Age=")
         append(SESSION_TTL_SECONDS)
         append("; HttpOnly; SameSite=Strict")
+        if (secure) append("; Secure")
+    }
+
+private fun buildCsrfCookie(
+    basePath: String,
+    value: String,
+    secure: Boolean,
+): String = buildCookie(CSRF_COOKIE_NAME, value, basePath, SESSION_TTL_SECONDS, secure)
+
+private fun buildExpiredCsrfCookie(basePath: String, secure: Boolean): String =
+    buildCookie(CSRF_COOKIE_NAME, "", basePath, 0, secure)
+
+private fun buildCookie(
+    name: String,
+    value: String,
+    basePath: String,
+    maxAge: Long,
+    secure: Boolean,
+): String =
+    buildString {
+        append("$name=$value; Path=$basePath/manage; Max-Age=$maxAge; HttpOnly; SameSite=Strict")
         if (secure) append("; Secure")
     }
 
@@ -235,6 +293,7 @@ private fun recoveryHtml(basePath: String): String =
 private fun manageHtml(
     basePath: String,
     installation: InstallationAdminContext,
+    csrf: String,
 ): String =
     buildString {
         append("<h1>Manage installation</h1>")
@@ -251,6 +310,7 @@ private fun manageHtml(
         append("<p>The new GitLab credential is shown once, on the next page only.</p>")
         append(
             "<form method=\"post\" action=\"${(basePath + "/manage/rotate").html()}\">" +
+                "<input type=\"hidden\" name=\"csrf\" value=\"${csrf.html()}\">" +
                 "<button type=\"submit\">Rotate credential</button></form>",
         )
         append("<h2>Recovery</h2>")
@@ -260,6 +320,7 @@ private fun manageHtml(
         )
         append(
             "<form method=\"post\" action=\"${(basePath + "/manage/logout").html()}\">" +
+                "<input type=\"hidden\" name=\"csrf\" value=\"${csrf.html()}\">" +
                 "<button type=\"submit\">Log out</button></form>",
         )
     }
@@ -279,7 +340,7 @@ private fun rotatedHtml(
         )
     }
 
-private fun managementDocument(title: String, body: String): String =
+internal fun managementDocument(title: String, body: String): String =
     """
     <!doctype html>
     <html lang="en">
@@ -300,7 +361,7 @@ private fun managementDocument(title: String, body: String): String =
     </html>
     """.trimIndent()
 
-private fun String.html(): String =
+internal fun String.html(): String =
     replace("&", "&amp;")
         .replace("<", "&lt;")
         .replace(">", "&gt;")

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/PlatformAdminRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/PlatformAdminRouting.kt
@@ -1,0 +1,309 @@
+package net.raquezha.nuecagram.plugins
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.plugins.origin
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import java.net.URI
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.raquezha.nuecagram.ConfigWithSecrets
+import net.raquezha.nuecagram.db.CredentialCodec
+import net.raquezha.nuecagram.db.InstallationAdminContext
+import net.raquezha.nuecagram.db.InstallationRepository
+import net.raquezha.nuecagram.db.PlatformAdminAuditRecord
+import net.raquezha.nuecagram.db.PlatformAdminSessionContext
+import org.koin.ktor.ext.inject
+import org.mindrot.jbcrypt.BCrypt
+
+private const val ADMIN_SESSION_COOKIE = "nuecagram_admin_session"
+private const val LOGIN_CSRF_COOKIE = "nuecagram_admin_login_csrf"
+private const val ADMIN_CSRF_COOKIE = "nuecagram_admin_csrf"
+private const val ADMIN_SESSION_HOURS = 8L
+private const val SECONDS_PER_MINUTE = 60L
+private const val ADMIN_SESSION_SECONDS = ADMIN_SESSION_HOURS * SECONDS_PER_MINUTE * SECONDS_PER_MINUTE
+private const val LOGIN_CSRF_SECONDS = 10 * SECONDS_PER_MINUTE
+private const val MAX_LOGIN_FAILURES = 5
+private const val MAX_PASSWORD_LENGTH = 1024
+private const val LOGIN_WINDOW_MINUTES = 15L
+
+@Suppress("LongMethod")
+fun Route.platformAdminRouting(basePath: String) {
+    val config by inject<ConfigWithSecrets>()
+    val installationRepository by inject<InstallationRepository>()
+    val loginThrottle = LoginThrottle()
+
+    get("$basePath/admin/login") {
+        if (call.platformAdminSession(installationRepository) != null) {
+            call.appendSecurityHeaders()
+            call.respondRedirect("$basePath/admin")
+            return@get
+        }
+        val csrf = CredentialCodec.issueCredential().first
+        call.response.headers.append(HttpHeaders.SetCookie, loginCsrfCookie(basePath, csrf, call.isHttps()))
+        call.respondManagementHtml(
+            title = "Platform administration",
+            body = adminLoginHtml(basePath, csrf),
+        )
+    }
+
+    post("$basePath/admin/login") {
+        val clientId = call.request.origin.remoteHost
+        if (loginThrottle.isBlocked(clientId)) {
+            call.response.headers.append(
+                HttpHeaders.RetryAfter,
+                (LOGIN_WINDOW_MINUTES * SECONDS_PER_MINUTE).toString(),
+            )
+            call.respondManagementHtml(
+                status = HttpStatusCode.TooManyRequests,
+                title = "Try again later",
+                body = "<h1>Try again later</h1><p>Too many failed login attempts.</p>",
+            )
+            return@post
+        }
+        val form = call.receiveParameters()
+        val csrf = form["csrf"].orEmpty()
+        val csrfCookie = call.request.cookies[LOGIN_CSRF_COOKIE].orEmpty()
+        if (!constantTimeEquals(csrf, csrfCookie)) {
+            call.respondManagementHtml(
+                status = HttpStatusCode.Forbidden,
+                title = "Request rejected",
+                body = "<h1>Request rejected</h1><p>Reload the login page and try again.</p>",
+            )
+            return@post
+        }
+        val password = form["password"].orEmpty()
+        val authenticated =
+            password.length in 1..MAX_PASSWORD_LENGTH &&
+                withContext(Dispatchers.Default) {
+                    runCatching { BCrypt.checkpw(password, config.platformAdminHash) }.getOrDefault(false)
+                }
+        if (!authenticated) {
+            loginThrottle.recordFailure(clientId)
+            call.respondManagementHtml(
+                status = HttpStatusCode.Unauthorized,
+                title = "Login failed",
+                body = adminLoginHtml(basePath, csrf, failed = true),
+            )
+            return@post
+        }
+
+        loginThrottle.clear(clientId)
+        val session =
+            installationRepository.issuePlatformAdminSession(
+                Instant.now().plus(ADMIN_SESSION_HOURS, ChronoUnit.HOURS),
+            )
+        call.response.headers.append(
+            HttpHeaders.SetCookie,
+            adminSessionCookie(basePath, session.raw, call.isHttps()),
+        )
+        call.response.headers.append(
+            HttpHeaders.SetCookie,
+            cookie(
+                ADMIN_CSRF_COOKIE,
+                session.csrf,
+                "$basePath/admin",
+                ADMIN_SESSION_SECONDS,
+                call.isHttps(),
+            ),
+        )
+        call.response.headers.append(
+            HttpHeaders.SetCookie,
+            expiredCookie(LOGIN_CSRF_COOKIE, "$basePath/admin", call.isHttps()),
+        )
+        call.appendSecurityHeaders()
+        call.respondRedirect("$basePath/admin")
+    }
+
+    get("$basePath/admin") {
+        val session = call.platformAdminSession(installationRepository)
+        if (session == null) {
+            call.clearAdminSession(basePath)
+            call.respondManagementHtml(
+                status = HttpStatusCode.Unauthorized,
+                title = "Platform login required",
+                body = adminLoginRequiredHtml(basePath),
+            )
+            return@get
+        }
+        val csrf = call.request.cookies[ADMIN_CSRF_COOKIE].orEmpty()
+        if (!installationRepository.verifyPlatformAdminCsrf(session, csrf)) {
+            call.clearAdminSession(basePath)
+            call.respondManagementHtml(
+                status = HttpStatusCode.Unauthorized,
+                title = "Platform login required",
+                body = adminLoginRequiredHtml(basePath),
+            )
+            return@get
+        }
+        call.respondManagementHtml(
+            title = "Platform administration",
+            body =
+                platformAdminHtml(
+                    basePath = basePath,
+                    csrf = csrf,
+                    installations = installationRepository.platformAdminInstallations(),
+                    auditEvents = installationRepository.platformAdminAuditEvents(),
+                ),
+        )
+    }
+
+    post("$basePath/admin/logout") {
+        val session = call.platformAdminSession(installationRepository)
+        val csrf = call.receiveParameters()["csrf"].orEmpty()
+        if (session == null || !installationRepository.verifyPlatformAdminCsrf(session, csrf)) {
+            call.respondManagementHtml(
+                status = HttpStatusCode.Forbidden,
+                title = "Request rejected",
+                body = "<h1>Request rejected</h1><p>The session or CSRF token is invalid.</p>",
+            )
+            return@post
+        }
+        installationRepository.deletePlatformAdminSession(session.id)
+        call.clearAdminSession(basePath)
+        call.appendSecurityHeaders()
+        call.respondRedirect("$basePath/admin/login")
+    }
+}
+
+private suspend fun ApplicationCall.platformAdminSession(
+    installationRepository: InstallationRepository,
+): PlatformAdminSessionContext? =
+    request.cookies[ADMIN_SESSION_COOKIE]
+        ?.takeIf(String::isNotBlank)
+        ?.let { installationRepository.verifyPlatformAdminSession(it) }
+
+private fun ApplicationCall.clearAdminSession(basePath: String) {
+    response.headers.append(
+        HttpHeaders.SetCookie,
+        expiredCookie(ADMIN_SESSION_COOKIE, "$basePath/admin", isHttps()),
+    )
+    response.headers.append(
+        HttpHeaders.SetCookie,
+        expiredCookie(ADMIN_CSRF_COOKIE, "$basePath/admin", isHttps()),
+    )
+}
+
+private fun adminSessionCookie(basePath: String, value: String, secure: Boolean): String =
+    cookie(
+        name = ADMIN_SESSION_COOKIE,
+        value = value,
+        path = "$basePath/admin",
+        maxAge = ADMIN_SESSION_SECONDS,
+        secure = secure,
+    )
+
+private fun loginCsrfCookie(basePath: String, value: String, secure: Boolean): String =
+    cookie(LOGIN_CSRF_COOKIE, value, "$basePath/admin", LOGIN_CSRF_SECONDS, secure)
+
+private fun expiredCookie(name: String, path: String, secure: Boolean): String =
+    cookie(name, "", path, 0, secure)
+
+private fun cookie(
+    name: String,
+    value: String,
+    path: String,
+    maxAge: Long,
+    secure: Boolean,
+): String =
+    buildString {
+        append("$name=$value; Path=$path; Max-Age=$maxAge; HttpOnly; SameSite=Strict")
+        if (secure) append("; Secure")
+    }
+
+private fun constantTimeEquals(left: String, right: String): Boolean =
+    left.isNotEmpty() &&
+        java.security.MessageDigest.isEqual(
+            left.toByteArray(Charsets.UTF_8),
+            right.toByteArray(Charsets.UTF_8),
+        )
+
+private fun adminLoginHtml(basePath: String, csrf: String, failed: Boolean = false): String =
+    buildString {
+        append("<h1>Platform administration</h1>")
+        if (failed) append("<p>Login failed.</p>")
+        append("<form method=\"post\" action=\"${(basePath + "/admin/login").html()}\">")
+        append("<input type=\"hidden\" name=\"csrf\" value=\"${csrf.html()}\">")
+        append("<label>Password <input type=\"password\" name=\"password\" required></label>")
+        append("<button type=\"submit\">Log in</button></form>")
+    }
+
+private fun adminLoginRequiredHtml(basePath: String): String =
+    """
+    <h1>Platform login required</h1>
+    <p><a href="${(basePath + "/admin/login").html()}">Log in</a></p>
+    """.trimIndent()
+
+private fun platformAdminHtml(
+    basePath: String,
+    csrf: String,
+    installations: List<InstallationAdminContext>,
+    auditEvents: List<PlatformAdminAuditRecord>,
+): String =
+    buildString {
+        append("<h1>Platform administration</h1>")
+        append("<h2>Installations</h2><table><thead><tr>")
+        append("<th>ID</th><th>GitLab</th><th>Project</th><th>Muted</th>")
+        append("</tr></thead><tbody>")
+        installations.forEach { installation ->
+            append("<tr><td><code>${installation.id.toString().html()}</code></td>")
+            append("<td>${installation.gitlabBaseUrl.redactedUrl().html()}</td>")
+            append("<td>${installation.gitlabProjectId?.toString()?.html().orEmpty()}</td>")
+            append("<td>${if (installation.muted) "yes" else "no"}</td></tr>")
+        }
+        append("</tbody></table>")
+        append("<h2>Recent audit events</h2><table><thead><tr>")
+        append("<th>Time</th><th>Installation</th><th>Action</th>")
+        append("</tr></thead><tbody>")
+        auditEvents.forEach { event ->
+            append("<tr><td>${event.createdAt.toString().html()}</td>")
+            append("<td>${event.installationId?.toString()?.html().orEmpty()}</td>")
+            append("<td>${event.action.html()}</td></tr>")
+        }
+        append("</tbody></table>")
+        append("<h2>Recovery</h2><p>Credential recovery is delivered only through ")
+        append("the verified Telegram administrator flow.</p>")
+        append("<form method=\"post\" action=\"${(basePath + "/admin/logout").html()}\">")
+        append("<input type=\"hidden\" name=\"csrf\" value=\"${csrf.html()}\">")
+        append("<button type=\"submit\">Log out</button></form>")
+    }
+
+private fun String.redactedUrl(): String =
+    runCatching {
+        val uri = URI(this)
+        require(uri.scheme in setOf("http", "https") && uri.host != null)
+        URI(uri.scheme, null, uri.host, uri.port, uri.path, null, null).toString()
+    }.getOrDefault("[invalid URL]")
+
+private class LoginThrottle {
+    // ponytail: process-local throttle; move to shared storage if the service runs multiple replicas.
+    private val failures = mutableMapOf<String, ArrayDeque<Instant>>()
+
+    @Synchronized
+    fun isBlocked(clientId: String, now: Instant = Instant.now()): Boolean =
+        recentFailures(clientId, now).size >= MAX_LOGIN_FAILURES
+
+    @Synchronized
+    fun recordFailure(clientId: String, now: Instant = Instant.now()) {
+        recentFailures(clientId, now).addLast(now)
+    }
+
+    @Synchronized
+    fun clear(clientId: String) {
+        failures.remove(clientId)
+    }
+
+    private fun recentFailures(clientId: String, now: Instant): ArrayDeque<Instant> {
+        val attempts = failures.getOrPut(clientId) { ArrayDeque() }
+        val cutoff = now.minus(LOGIN_WINDOW_MINUTES, ChronoUnit.MINUTES)
+        while (attempts.firstOrNull()?.isBefore(cutoff) == true) attempts.removeFirst()
+        return attempts
+    }
+}

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
@@ -49,6 +49,7 @@ fun Application.configureRouting() {
 
         telegramRouting(this@configureRouting.basePath())
         managementRouting(this@configureRouting.basePath())
+        platformAdminRouting(this@configureRouting.basePath())
 
         post("/webhook") {
             try {
@@ -95,6 +96,7 @@ fun Application.configureRouting() {
                     webhookService.cleanupStaleEntries()
                     installationRepository.cleanupExpiredManagementLinks()
                     installationRepository.cleanupExpiredManagementSessions()
+                    installationRepository.cleanupExpiredPlatformAdminSessions()
                     logger.debug { "Periodic cleanup completed" }
                 } catch (e: Exception) {
                     logger.error(e) { "Periodic cleanup failed: ${e.message}" }

--- a/src/main/resources/db/migration/V5__platform_admin_sessions.sql
+++ b/src/main/resources/db/migration/V5__platform_admin_sessions.sql
@@ -1,0 +1,16 @@
+ALTER TABLE management_sessions
+    ADD COLUMN csrf_digest BYTEA,
+    ADD COLUMN csrf_hash TEXT;
+
+CREATE TABLE platform_admin_sessions (
+    id UUID PRIMARY KEY,
+    token_digest BYTEA NOT NULL UNIQUE,
+    token_hash TEXT NOT NULL,
+    csrf_digest BYTEA NOT NULL,
+    csrf_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX platform_admin_sessions_expiry
+    ON platform_admin_sessions (expires_at);

--- a/src/test/kotlin/net/raquezha/nuecagram/DatabaseFactoryTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/DatabaseFactoryTest.kt
@@ -56,6 +56,8 @@ val DatabaseFactoryTests by testSuite {
                 "installations",
                 "webhook_secrets",
                 "management_links",
+                "management_sessions",
+                "platform_admin_sessions",
                 "audit_events",
                 "event_summaries",
                 "mute_states",

--- a/src/test/kotlin/net/raquezha/nuecagram/InstallationRepositoryTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/InstallationRepositoryTest.kt
@@ -80,9 +80,10 @@ val InstallationRepositoryTests by testSuite {
                 Instant.now().plus(8, ChronoUnit.HOURS),
             )
             assertThat(session).isNotNull()
-            assertThat(
-                repository.verifyManagementSession(session!!.raw)?.installationId,
-            ).isEqualTo(installation.id)
+            val verifiedSession = repository.verifyManagementSession(session!!.raw)
+            assertThat(verifiedSession?.installationId).isEqualTo(installation.id)
+            assertThat(repository.verifyManagementCsrf(verifiedSession!!, session.csrf)).isTrue()
+            assertThat(repository.verifyManagementCsrf(verifiedSession, "invalid")).isFalse()
             assertThat(
                 repository.exchangeManagementLinkForSession(
                     sessionLink.raw,
@@ -127,8 +128,12 @@ val InstallationRepositoryTests by testSuite {
                 Instant.now().minus(1, ChronoUnit.MINUTES),
             )
             assertThat(session).isNotNull()
+            val platformSession =
+                repository.issuePlatformAdminSession(Instant.now().minus(1, ChronoUnit.MINUTES))
+            assertThat(repository.verifyPlatformAdminSession(platformSession.raw)).isNull()
             assertThat(repository.cleanupExpiredManagementLinks()).isEqualTo(1)
             assertThat(repository.cleanupExpiredManagementSessions()).isEqualTo(1)
+            assertThat(repository.cleanupExpiredPlatformAdminSessions()).isEqualTo(1)
             assertThat(repository.cleanupExpiredWebhookSecrets()).isEqualTo(1)
 
             repository.writeAuditEvent(

--- a/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
@@ -1,12 +1,15 @@
 package net.raquezha.nuecagram
 
 import com.google.common.truth.Truth.assertThat
+import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import java.time.Instant
@@ -54,10 +57,12 @@ class ManagementUiTest : BaseEventTestHelper() {
             assertThat(setCookie).contains("SameSite=Strict")
             assertThat(setCookie).contains("Path=${basePath()}/manage")
 
-            val session = setCookie.substringAfter("nuecagram_manage_session=").substringBefore(';')
+            val cookies =
+                response.headers.getAll(HttpHeaders.SetCookie).orEmpty()
+                    .joinToString("; ") { it.substringBefore(';') }
             val page =
                 client.get("${basePath()}/manage") {
-                    header(HttpHeaders.Cookie, "nuecagram_manage_session=$session")
+                    header(HttpHeaders.Cookie, cookies)
                     header("X-Forwarded-Proto", "https")
                 }
 
@@ -134,10 +139,16 @@ class ManagementUiTest : BaseEventTestHelper() {
             val oldCredential = runBlocking { installationRepository.issueWebhookSecret(installation.id).raw }
             val session = exchangeSessionCookie(client.config { followRedirects = false })
 
+            val managePage =
+                client.get("${basePath()}/manage") {
+                    header(HttpHeaders.Cookie, session)
+                }
+            val csrf = hiddenValue(managePage.bodyAsText(), "csrf")
             val rotate =
                 client.post("${basePath()}/manage/rotate") {
                     header(HttpHeaders.Cookie, session)
                     header("X-Forwarded-Proto", "https")
+                    setBody(FormDataContent(Parameters.build { append("csrf", csrf) }))
                 }
 
             assertThat(rotate.status).isEqualTo(HttpStatusCode.OK)
@@ -186,10 +197,23 @@ class ManagementUiTest : BaseEventTestHelper() {
             val session = exchangeSessionCookie(client.config { followRedirects = false })
             val noRedirectClient = client.config { followRedirects = false }
 
+            val page =
+                client.get("${basePath()}/manage") {
+                    header(HttpHeaders.Cookie, session)
+                }
+            val csrf = hiddenValue(page.bodyAsText(), "csrf")
+            val rejected =
+                noRedirectClient.post("${basePath()}/manage/logout") {
+                    header(HttpHeaders.Cookie, session)
+                    setBody(FormDataContent(Parameters.build { append("csrf", "invalid") }))
+                }
+            assertThat(rejected.status).isEqualTo(HttpStatusCode.Forbidden)
+
             val response =
                 noRedirectClient.post("${basePath()}/manage/logout") {
                     header(HttpHeaders.Cookie, session)
                     header("X-Forwarded-Proto", "https")
+                    setBody(FormDataContent(Parameters.build { append("csrf", csrf) }))
                 }
 
             assertThat(response.status).isEqualTo(HttpStatusCode.Found)
@@ -233,11 +257,12 @@ class ManagementUiTest : BaseEventTestHelper() {
                     header("X-Forwarded-Proto", "https")
                 }
             }
-        val session = response.headers[HttpHeaders.SetCookie].orEmpty()
-            .substringAfter("nuecagram_manage_session=")
-            .substringBefore(';')
-        return "nuecagram_manage_session=$session"
+        return response.headers.getAll(HttpHeaders.SetCookie).orEmpty()
+            .joinToString("; ") { it.substringBefore(';') }
     }
+
+    private fun hiddenValue(body: String, name: String): String =
+        body.substringAfter("name=\"$name\" value=\"").substringBefore('"')
 
     private fun basePath(): String = configuredBasePath()
 }

--- a/src/test/kotlin/net/raquezha/nuecagram/PlatformAdminUiTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/PlatformAdminUiTest.kt
@@ -1,0 +1,189 @@
+package net.raquezha.nuecagram
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class PlatformAdminUiTest : BaseEventTestHelper() {
+    @Test
+    fun platformAdminLoginShowsRedactedInstallationAndAuditViews() =
+        testApplication {
+            configureTestApplication()
+            val installationWithCredentialInUrl =
+                runBlocking {
+                    installationRepository.createInstallation(
+                        gitlabBaseUrl = "https://url-user:url-secret@gitlab.example/group?token=url-token",
+                        gitlabProjectId = null,
+                        telegramChatId = 900001,
+                        telegramTopicId = null,
+                    )
+                }
+            runBlocking {
+                installationRepository.writeAuditEvent(
+                    installationId = installation.id,
+                    actorType = "telegram_user",
+                    actorId = "sensitive-actor-id",
+                    action = "setup",
+                    metadataJson = "{\"credential\":\"must-not-appear\"}",
+                )
+            }
+            val noRedirectClient = client.config { followRedirects = false }
+            val sessionCookie = login(noRedirectClient)
+
+            val response =
+                client.get("${basePath()}/admin") {
+                    header(HttpHeaders.Cookie, sessionCookie)
+                    header("X-Forwarded-Proto", "https")
+                }
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+            val body = response.bodyAsText()
+            assertThat(body).contains(installation.id.toString())
+            assertThat(body).contains(installation.gitlabBaseUrl)
+            assertThat(body).contains(installationWithCredentialInUrl.id.toString())
+            assertThat(body).contains("https://gitlab.example/group")
+            assertThat(body).contains("setup")
+            assertThat(body).doesNotContain("sensitive-actor-id")
+            assertThat(body).doesNotContain("must-not-appear")
+            assertThat(body).doesNotContain("url-user")
+            assertThat(body).doesNotContain("url-secret")
+            assertThat(body).doesNotContain("url-token")
+            assertThat(body).doesNotContain(installation.telegramChatId.toString())
+            assertThat(body).doesNotContain("management link")
+            assertThat(response.headers["Content-Security-Policy"]).contains("default-src 'none'")
+        }
+
+    @Test
+    fun platformAdminLoginIsThrottledAfterRepeatedFailures() =
+        testApplication {
+            configureTestApplication()
+            val noRedirectClient = client.config { followRedirects = false }
+            val loginForm = loginForm(noRedirectClient)
+
+            repeat(5) {
+                val response = submitLogin(noRedirectClient, loginForm, "wrong-password")
+                assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+            }
+
+            val throttled = submitLogin(noRedirectClient, loginForm, TEST_ADMIN_PASSWORD)
+            assertThat(throttled.status).isEqualTo(HttpStatusCode.TooManyRequests)
+        }
+
+    @Test
+    fun platformAdminLogoutRequiresCsrfAndInvalidatesSession() =
+        testApplication {
+            configureTestApplication()
+            val noRedirectClient = client.config { followRedirects = false }
+            val sessionCookie = login(noRedirectClient)
+            val page =
+                client.get("${basePath()}/admin") {
+                    header(HttpHeaders.Cookie, sessionCookie)
+                }
+            val csrf = hiddenValue(page.bodyAsText(), "csrf")
+
+            val rejected =
+                noRedirectClient.post("${basePath()}/admin/logout") {
+                    header(HttpHeaders.Cookie, sessionCookie)
+                    setBody(FormDataContent(Parameters.build { append("csrf", "invalid") }))
+                }
+            assertThat(rejected.status).isEqualTo(HttpStatusCode.Forbidden)
+
+            val logout =
+                noRedirectClient.post("${basePath()}/admin/logout") {
+                    header(HttpHeaders.Cookie, sessionCookie)
+                    setBody(FormDataContent(Parameters.build { append("csrf", csrf) }))
+                }
+            assertThat(logout.status).isEqualTo(HttpStatusCode.Found)
+            assertThat(logout.headers[HttpHeaders.SetCookie].orEmpty()).contains("Max-Age=0")
+
+            val afterLogout =
+                client.get("${basePath()}/admin") {
+                    header(HttpHeaders.Cookie, sessionCookie)
+                }
+            assertThat(afterLogout.status).isEqualTo(HttpStatusCode.Unauthorized)
+        }
+
+    @Test
+    fun expiredPlatformAdminSessionIsRejected() =
+        testApplication {
+            configureTestApplication()
+            val expired = runBlocking {
+                installationRepository.issuePlatformAdminSession(
+                    Instant.now().minus(1, ChronoUnit.MINUTES),
+                )
+            }
+
+            val response =
+                client.get("${basePath()}/admin") {
+                    header(HttpHeaders.Cookie, "nuecagram_admin_session=${expired.raw}")
+                }
+
+            assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+            assertThat(response.headers[HttpHeaders.SetCookie].orEmpty()).contains("Max-Age=0")
+        }
+
+    private suspend fun ApplicationTestBuilder.login(noRedirectClient: HttpClient): String {
+        val form = loginForm(noRedirectClient)
+        val response = submitLogin(noRedirectClient, form, TEST_ADMIN_PASSWORD)
+        assertThat(response.status).isEqualTo(HttpStatusCode.Found)
+        assertThat(response.headers[HttpHeaders.Location]).isEqualTo("${basePath()}/admin")
+        val cookies = response.headers.getAll(HttpHeaders.SetCookie).orEmpty()
+        assertThat(cookies.joinToString()).contains("HttpOnly")
+        assertThat(cookies.joinToString()).contains("SameSite=Strict")
+        return cookies
+            .filterNot { it.startsWith("nuecagram_admin_login_csrf=") }
+            .joinToString("; ") { it.substringBefore(';') }
+    }
+
+    private suspend fun ApplicationTestBuilder.loginForm(noRedirectClient: HttpClient): LoginForm {
+        val response = noRedirectClient.get("${basePath()}/admin/login")
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        return LoginForm(
+            csrf = hiddenValue(response.bodyAsText(), "csrf"),
+            cookie = response.headers[HttpHeaders.SetCookie].orEmpty().substringBefore(';'),
+        )
+    }
+
+    private suspend fun ApplicationTestBuilder.submitLogin(
+        noRedirectClient: HttpClient,
+        form: LoginForm,
+        password: String,
+    ): HttpResponse =
+        noRedirectClient.post("${basePath()}/admin/login") {
+            header(HttpHeaders.Cookie, form.cookie)
+            setBody(
+                FormDataContent(
+                    Parameters.build {
+                        append("csrf", form.csrf)
+                        append("password", password)
+                    },
+                ),
+            )
+        }
+
+    private fun hiddenValue(body: String, name: String): String =
+        body.substringAfter("name=\"$name\" value=\"").substringBefore('"')
+
+    private fun basePath(): String = configuredBasePath()
+
+    private data class LoginForm(val csrf: String, val cookie: String)
+
+    companion object {
+        const val TEST_ADMIN_PASSWORD = "test-admin-password"
+    }
+}


### PR DESCRIPTION
## Summary
- Add password-hash authenticated platform administration under the configured base path.
- Add server-side admin sessions, CSRF protection for browser mutations, login throttling, and redacted installation/audit views.
- Extend management-session mutations with CSRF protection and server-side logout invalidation.

## Scope
- Platform admin routing, secure cookies, session persistence, and cleanup.
- Flyway V5 migration for platform sessions and management-session CSRF data.
- Focused platform admin, management UI, repository, and migration coverage.

## Verification
- [x] `./gradlew lintKotlinMain lintKotlinTest detekt test build`
- [x] `./gradlew clean test` (run twice)
- [x] `reposcry validate main HEAD`
- [ ] Docker-backed PostgreSQL tests were skipped locally because Docker is unavailable; GitHub CI confirmation is required.

## Risk / Rollback
- Risk: Authentication, cookie, or migration regressions could block management/admin access; webhook delivery is unchanged.
- Rollback: Revert commit `06cf3cd`; the additive V5 tables/columns can remain harmlessly if migration already ran.

## RPIV Task
- Task: `github:49`
- Slice: S6 - Platform administration
- Branch: `feat/github-49-s6-platform-admin`

## Human Review Checklist
- [ ] Review changed files for repo conventions.
- [ ] Confirm verification evidence is sufficient.
- [ ] Confirm no secrets, local-only paths, or scratch artifacts are included.
