### PR TITLE
feat: add public URL based ingress

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/Application.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/Application.kt
@@ -32,7 +32,8 @@ fun main() {
 private fun validateRequiredEnvironmentVariables() {
     if (System.getenv("TELEGRAM_BOT_TOKEN").isNullOrBlank() ||
         System.getenv("TELEGRAM_WEBHOOK_SECRET").isNullOrBlank() ||
-        System.getenv("PLATFORM_ADMIN_PASSWORD_HASH").isNullOrBlank()
+        System.getenv("PLATFORM_ADMIN_PASSWORD_HASH").isNullOrBlank() ||
+        System.getenv("NUECAGRAM_PUBLIC_URL").isNullOrBlank()
     ) {
         throw IllegalStateException(
             """
@@ -40,6 +41,7 @@ private fun validateRequiredEnvironmentVariables() {
               - TELEGRAM_BOT_TOKEN
               - TELEGRAM_WEBHOOK_SECRET
               - PLATFORM_ADMIN_PASSWORD_HASH
+              - NUECAGRAM_PUBLIC_URL
 
             Please set these variables before starting the application.
             """.trimIndent(),

--- a/src/main/kotlin/net/raquezha/nuecagram/Config.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/Config.kt
@@ -1,5 +1,6 @@
 package net.raquezha.nuecagram
 
+import java.net.URI
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,11 +11,68 @@ data class Config(
     val port: Int,
 )
 
+fun configuredPublicUrl(): String =
+    normalizedPublicUrl(
+        System.getProperty("nuecagram.publicUrl") ?: System.getenv("NUECAGRAM_PUBLIC_URL") ?: defaultPublicUrl(),
+    )
+
 fun configuredBasePath(): String =
+    configuredPublicUrlPath()
+        ?: legacyBasePath()
+
+fun configuredRoute(path: String): String {
+    require(path.startsWith('/')) { "Route path must start with '/'" }
+    val basePath = configuredBasePath()
+    return if (basePath.isEmpty()) path else "$basePath$path"
+}
+
+private fun configuredPublicUrlPath(): String? =
+    publicUrlOverride()?.let { URI.create(normalizedPublicUrl(it)).path.normalizedBasePath() }
+
+private fun publicUrlOverride(): String? =
+    (System.getProperty("nuecagram.publicUrl") ?: System.getenv("NUECAGRAM_PUBLIC_URL"))
+        ?.trim()
+        ?.takeIf(String::isNotBlank)
+
+private fun legacyBasePath(): String =
     (System.getProperty("nuecagram.basePath") ?: System.getenv("NUECAGRAM_BASE_PATH") ?: "/nuecagram")
         .trim()
+        .normalizedBasePath()
+
+private fun defaultPublicUrl(): String {
+    val config = config("/application.json")
+    val host = config.host.removeSuffix("/")
+    return when {
+        host.startsWith("http://") || host.startsWith("https://") -> "$host${legacyBasePath()}"
+        host == "localhost" -> "http://$host:${config.port}${legacyBasePath()}"
+        else -> "https://$host${legacyBasePath()}"
+    }
+}
+
+private fun normalizedPublicUrl(raw: String): String {
+    val uri = URI.create(raw.trim())
+    require(uri.isAbsolute) { "NUECAGRAM_PUBLIC_URL must be absolute" }
+    require(uri.scheme == "https" || uri.scheme == "http") { "NUECAGRAM_PUBLIC_URL must use http or https" }
+    require(!uri.host.isNullOrBlank()) { "NUECAGRAM_PUBLIC_URL must include a host" }
+    require(uri.rawQuery == null) { "NUECAGRAM_PUBLIC_URL must not include a query" }
+    require(uri.rawFragment == null) { "NUECAGRAM_PUBLIC_URL must not include a fragment" }
+
+    val path = uri.path.normalizedBasePath()
+    return URI(
+        uri.scheme,
+        uri.userInfo,
+        uri.host,
+        uri.port,
+        path.ifEmpty { "/" },
+        null,
+        null,
+    ).toString().removeSuffix("/")
+}
+
+private fun String.normalizedBasePath(): String =
+    trim()
+        .ifBlank { "/" }
+        .also { require(it.startsWith('/')) { "NUECAGRAM base path must start with '/'" } }
         .removeSuffix("/")
-        .ifBlank { "/nuecagram" }
-        .also {
-            require(it.startsWith('/')) { "NUECAGRAM_BASE_PATH must start with '/'" }
-        }
+        .takeUnless { it.isEmpty() || it == "/" }
+        .orEmpty()

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/ManagementRouting.kt
@@ -26,7 +26,7 @@ private const val ROTATION_GRACE_MINUTES = 0L
 fun Route.managementRouting(basePath: String) {
     val installationRepository by inject<InstallationRepository>()
 
-    get(basePath) {
+    get(basePath.ifEmpty { "/" }) {
         call.respondManagementHtml(
             title = "Nuecagram setup",
             body = onboardingHtml(basePath),
@@ -173,7 +173,7 @@ fun Route.managementRouting(basePath: String) {
         installationRepository.deleteManagementSession(session.sessionId)
         call.clearManagementSession(basePath)
         call.appendSecurityHeaders()
-        call.respondRedirect(basePath)
+        call.respondRedirect(basePath.ifEmpty { "/" })
     }
 }
 

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
@@ -12,6 +12,7 @@ import io.ktor.server.routing.routing
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import net.raquezha.nuecagram.configuredRoute
 import net.raquezha.nuecagram.db.DatabaseFactory
 import net.raquezha.nuecagram.db.InstallationRepository
 import net.raquezha.nuecagram.webhook.SkipEventException
@@ -24,7 +25,7 @@ import org.koin.ktor.ext.inject
 private const val QUEUE_RESTART_DELAY_MS = 5000L
 private const val CLEANUP_INTERVAL_MS = 30 * 60 * 1000L // 30 minutes
 
-private fun Application.healthPath() = basePath() + "/health"
+private fun Application.healthPath() = configuredRoute("/health")
 
 @Suppress("LongMethod")
 fun Application.configureRouting() {
@@ -51,7 +52,7 @@ fun Application.configureRouting() {
         managementRouting(this@configureRouting.basePath())
         platformAdminRouting(this@configureRouting.basePath())
 
-        post("/webhook") {
+        post(configuredRoute("/webhook")) {
             try {
                 val webhookData = webhookService.handleRequest(call)
                 logger.debug {

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import net.raquezha.nuecagram.ConfigWithSecrets
-import net.raquezha.nuecagram.configuredBasePath
+import net.raquezha.nuecagram.configuredPublicUrl
 import net.raquezha.nuecagram.db.InstallationAdminContext
 import net.raquezha.nuecagram.db.InstallationRecord
 import net.raquezha.nuecagram.db.InstallationRepository
@@ -328,19 +328,12 @@ private fun InstallationAdminContext.deliveryTestMessage(): Message =
 private fun managementLinkExpiry(): Instant =
     Instant.now().plus(MANAGEMENT_LINK_TTL_MINUTES, ChronoUnit.MINUTES)
 
-private fun ConfigWithSecrets.publicBaseUrl(): String {
-    val host = host.removeSuffix("/")
-    return when {
-        host.startsWith("http://") || host.startsWith("https://") -> host
-        host == "localhost" -> "http://$host:$port"
-        else -> "https://$host"
-    }
-}
+private fun ConfigWithSecrets.publicBaseUrl(): String = configuredPublicUrl()
 
 private fun ConfigWithSecrets.webhookUrl(): String = "${publicBaseUrl()}/webhook"
 
 private fun ConfigWithSecrets.managementUrl(code: String): String =
-    "${publicBaseUrl()}${configuredBasePath()}/manage/$code"
+    "${publicBaseUrl()}/manage/$code"
 
 private fun setupDetailsText(
     config: ConfigWithSecrets,

--- a/src/test/kotlin/net/raquezha/nuecagram/ApplicationTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/ApplicationTest.kt
@@ -1,11 +1,17 @@
 package net.raquezha.nuecagram
 
 import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.testApplication
+import net.raquezha.nuecagram.webhook.NuecagramHeaders.GITLAB_EVENT
+import net.raquezha.nuecagram.webhook.NuecagramHeaders.GITLAB_TOKEN
 import net.raquezha.nuecagram.plugins.configureRouting
 import net.raquezha.nuecagram.di.testAppModule
+import org.junit.After
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.BeforeClass
@@ -35,6 +41,76 @@ class ApplicationTest {
             assertEquals(HttpStatusCode.OK, client.get("/nuecagram/health/live").status)
             assertEquals(HttpStatusCode.ServiceUnavailable, client.get("/nuecagram/health/ready").status)
         }
+
+    @Test
+    fun rootWebhookRouteIsNotRegistered() =
+        testApplication {
+            application {
+                configureRouting()
+            }
+            val response =
+                client.post("/webhook") {
+                    header(GITLAB_EVENT, "Push Hook")
+                    header(GITLAB_TOKEN, "unused")
+                    setBody("{}")
+                }
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
+    fun configuredPublicUrlRejectsQueryAndFragment() {
+        val previous = System.getProperty("nuecagram.publicUrl")
+        try {
+            System.setProperty("nuecagram.publicUrl", "https://example.com/nuecagram?bad=1")
+            kotlin.runCatching { configuredPublicUrl() }
+                .exceptionOrNull()
+                ?.message
+                ?.let { assertEquals("NUECAGRAM_PUBLIC_URL must not include a query", it) }
+                ?: throw AssertionError("Expected invalid public URL")
+
+            System.setProperty("nuecagram.publicUrl", "https://example.com/nuecagram#bad")
+            kotlin.runCatching { configuredPublicUrl() }
+                .exceptionOrNull()
+                ?.message
+                ?.let { assertEquals("NUECAGRAM_PUBLIC_URL must not include a fragment", it) }
+                ?: throw AssertionError("Expected invalid public URL")
+        } finally {
+            if (previous == null) {
+                System.clearProperty("nuecagram.publicUrl")
+            } else {
+                System.setProperty("nuecagram.publicUrl", previous)
+            }
+        }
+    }
+
+    @Test
+    fun publicUrlPathControlsRoutePrefix() {
+        val previous = System.getProperty("nuecagram.publicUrl")
+        System.setProperty("nuecagram.publicUrl", "https://example.com")
+        try {
+            testApplication {
+                application {
+                    configureRouting()
+                }
+                assertEquals(HttpStatusCode.OK, client.get("/health/live").status)
+                assertEquals(HttpStatusCode.OK, client.get("/setup").status)
+                assertEquals("", configuredBasePath())
+                assertEquals("https://example.com", configuredPublicUrl())
+                assertEquals(HttpStatusCode.NotFound, client.get("/nuecagram/health/live").status)
+            }
+        } finally {
+            if (previous == null) {
+                System.clearProperty("nuecagram.publicUrl")
+            } else {
+                System.setProperty("nuecagram.publicUrl", previous)
+            }
+        }
+    }
+
+    @After
+    fun clearPublicUrl() {
+        System.clearProperty("nuecagram.publicUrl")
+    }
 
     companion object {
         @BeforeClass

--- a/src/test/kotlin/net/raquezha/nuecagram/BaseEventTestHelper.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/BaseEventTestHelper.kt
@@ -88,7 +88,7 @@ abstract class BaseEventTestHelper : KoinTest {
         token: String = webhookToken,
         extraHeaders: HeadersBuilder.() -> Unit = {},
     ): HttpResponse =
-        client.post("/webhook") {
+        client.post(configuredRoute("/webhook")) {
             setBody(payload)
             contentType(ContentType.Application.Json)
             headers {

--- a/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/ManagementUiTest.kt
@@ -23,11 +23,13 @@ class ManagementUiTest : BaseEventTestHelper() {
     @Before
     fun resetBasePath() {
         System.clearProperty("nuecagram.basePath")
+        System.clearProperty("nuecagram.publicUrl")
     }
 
     @After
     fun clearBasePath() {
         System.clearProperty("nuecagram.basePath")
+        System.clearProperty("nuecagram.publicUrl")
     }
 
     @Test
@@ -225,8 +227,8 @@ class ManagementUiTest : BaseEventTestHelper() {
 
     @Test
     fun setupPageUsesConfiguredBasePath() {
-        val previous = System.getProperty("nuecagram.basePath")
-        System.setProperty("nuecagram.basePath", "/managed")
+        val previous = System.getProperty("nuecagram.publicUrl")
+        System.setProperty("nuecagram.publicUrl", "https://example.com/managed")
         try {
             testApplication {
                 configureTestApplication()
@@ -235,9 +237,9 @@ class ManagementUiTest : BaseEventTestHelper() {
             }
         } finally {
             if (previous == null) {
-                System.clearProperty("nuecagram.basePath")
+                System.clearProperty("nuecagram.publicUrl")
             } else {
-                System.setProperty("nuecagram.basePath", previous)
+                System.setProperty("nuecagram.publicUrl", previous)
             }
         }
     }

--- a/src/test/kotlin/net/raquezha/nuecagram/TelegramOnboardingWebhookTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/TelegramOnboardingWebhookTest.kt
@@ -34,37 +34,50 @@ class TelegramOnboardingWebhookTest : BaseEventTestHelper() {
         }
 
     @Test
-    fun setupSendsCredentialOnlyToPrivateChatAndAudits() =
-        testApplication {
-            configureTestApplication()
-            bootstrapPrivateUser(71)
-            mockTelegramService().setChatMemberStatus(installation.telegramChatId, 71, "administrator")
-            val initialSetupAuditCount = auditActionCount("telegram_setup")
-            val initialLinkAuditCount = auditActionCount("telegram_management_link")
+    fun setupSendsCredentialOnlyToPrivateChatAndAudits() {
+        val previous = System.getProperty("nuecagram.publicUrl")
+        System.setProperty("nuecagram.publicUrl", "https://android.nweca.com/nuecagram")
+        try {
+            testApplication {
+                configureTestApplication()
+                bootstrapPrivateUser(71)
+                mockTelegramService().setChatMemberStatus(installation.telegramChatId, 71, "administrator")
+                val initialSetupAuditCount = auditActionCount("telegram_setup")
+                val initialLinkAuditCount = auditActionCount("telegram_management_link")
 
-            assertThat(
-                postTelegram(
-                    groupUpdate(
-                        71,
-                        "/setup https://gitlab.example.com 321 777",
-                        installation.telegramChatId,
-                        userId = 71,
-                    ),
-                ).status,
-            ).isEqualTo(HttpStatusCode.OK)
+                assertThat(
+                    postTelegram(
+                        groupUpdate(
+                            71,
+                            "/setup https://gitlab.example.com 321 777",
+                            installation.telegramChatId,
+                            userId = 71,
+                        ),
+                    ).status,
+                ).isEqualTo(HttpStatusCode.OK)
 
-            val privateMessage = messagesForChat(71).single()
-            val groupMessage = messagesForChat(installation.telegramChatId).single()
-            assertThat(privateMessage.text).contains("GitLab credential:")
-            assertThat(privateMessage.text).contains("Management URL:")
-            assertThat(privateMessage.text).contains("Webhook URL:")
-            assertThat(groupMessage.text).isEqualTo("Private setup details sent.")
-            assertThat(groupMessage.text).doesNotContain("GitLab credential:")
-            assertThat(groupMessage.text).doesNotContain("Management URL:")
-            assertThat(installationCount("https://gitlab.example.com", 321L)).isEqualTo(1)
-            assertThat(auditActionCount("telegram_setup")).isEqualTo(initialSetupAuditCount + 1)
-            assertThat(auditActionCount("telegram_management_link")).isEqualTo(initialLinkAuditCount + 1)
+                val privateMessage = messagesForChat(71).single()
+                val groupMessage = messagesForChat(installation.telegramChatId).single()
+                assertThat(privateMessage.text).contains("GitLab credential:")
+                assertThat(privateMessage.text).contains("Management URL:")
+                assertThat(privateMessage.text).contains("Webhook URL:")
+                assertThat(privateMessage.text).contains("https://android.nweca.com/nuecagram/webhook")
+                assertThat(privateMessage.text).contains("https://android.nweca.com/nuecagram/manage/")
+                assertThat(groupMessage.text).isEqualTo("Private setup details sent.")
+                assertThat(groupMessage.text).doesNotContain("GitLab credential:")
+                assertThat(groupMessage.text).doesNotContain("Management URL:")
+                assertThat(installationCount("https://gitlab.example.com", 321L)).isEqualTo(1)
+                assertThat(auditActionCount("telegram_setup")).isEqualTo(initialSetupAuditCount + 1)
+                assertThat(auditActionCount("telegram_management_link")).isEqualTo(initialLinkAuditCount + 1)
+            }
+        } finally {
+            if (previous == null) {
+                System.clearProperty("nuecagram.publicUrl")
+            } else {
+                System.setProperty("nuecagram.publicUrl", previous)
+            }
         }
+    }
 
     @Test
     fun manageSendsPrivateLinkOnlyOnceForDuplicateUpdates() =

--- a/src/test/kotlin/net/raquezha/nuecagram/api/issue-event-closed.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/issue-event-closed.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/webhook
+POST http://localhost:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/issue-event-created.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/issue-event-created.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Issue Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/issue-event-updated.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/issue-event-updated.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Issue Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/job-event-0created.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/job-event-0created.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Job Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/job-event-1pending.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/job-event-1pending.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Job Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/job-event-2running.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/job-event-2running.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Job Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/job-event-3canceled.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/job-event-3canceled.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/job-event-4failed.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/job-event-4failed.http
@@ -1,4 +1,4 @@
-POST http://localhost:80/webhook
+POST http://localhost:80/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Job Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/job-event-5success.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/job-event-5success.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Job Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/merge-request-event-opened.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/merge-request-event-opened.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Merge Request Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/note-event-1comment-on-commit.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/note-event-1comment-on-commit.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/webhook
+POST http://localhost:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Note Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/note-event-2comment-on-merge.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/note-event-2comment-on-merge.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/webhook
+POST http://localhost:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Note Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/note-event-3comment-on-issue.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/note-event-3comment-on-issue.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/webhook
+POST http://localhost:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Note Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/pipeline-event-1-failed.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/pipeline-event-1-failed.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Pipeline Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/pipeline-event-1-running.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/pipeline-event-1-running.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Pipeline Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/pipeline-event-2-cancelled.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/pipeline-event-2-cancelled.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Pipeline Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/push-event-commit.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/push-event-commit.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/webhook
+POST http://localhost:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/push-event-create-branch.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/push-event-create-branch.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/push-event-delete-branch.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/push-event-delete-branch.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/release-event-create.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/release-event-create.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/release-event-delete.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/release-event-delete.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/release-event-update.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/release-event-update.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/tag-push-event.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/tag-push-event.http
@@ -1,4 +1,4 @@
-POST http://0.0.0.0:8080/webhook
+POST http://0.0.0.0:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Push Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/wiki-event-create.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/wiki-event-create.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Wiki Page Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/wiki-event-delete.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/wiki-event-delete.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Wiki Page Hook

--- a/src/test/kotlin/net/raquezha/nuecagram/api/wiki-event-update.http
+++ b/src/test/kotlin/net/raquezha/nuecagram/api/wiki-event-update.http
@@ -1,4 +1,4 @@
-POST http://127.0.0.1:8080/webhook
+POST http://127.0.0.1:8080/nuecagram/webhook
 Content-Type: application/json
 User-Agent: GitLab/16.11.2-ee
 X-Gitlab-Event: Wiki Page Hook


### PR DESCRIPTION
## Summary
- Add `NUECAGRAM_PUBLIC_URL` handling and derive the app route prefix from its path.
- Move GitLab ingress to the base-path-aware webhook route and remove the legacy root `/webhook` route.
- Generate Telegram-delivered webhook and management URLs from the configured public application root.

## Scope
- Updated public URL/base-path configuration and runtime validation.
- Updated routing, management redirects, webhook test helpers, onboarding URL generation, and webhook fixture URLs.
- Added coverage for public URL validation, root-vs-prefixed routing, generated URLs, and missing root webhook ingress.

## Verification
- [x] `./gradlew test --tests "net.raquezha.nuecagram.ApplicationTest" --tests "net.raquezha.nuecagram.ManagementUiTest" --tests "net.raquezha.nuecagram.TelegramOnboardingWebhookTest"`
- [x] `./gradlew test`
- [x] `./gradlew lintKotlinMain lintKotlinTest detekt test build`
- [x] `./gradlew clean test` (run twice)
- [x] `reposcry validate main HEAD`
- [x] `reposcry --repo . get_affected_flows main HEAD`
- [x] GitHub CI confirmation pending

## Risk / Rollback
- Risk: Route-prefix derivation now depends on `NUECAGRAM_PUBLIC_URL`, so bad configuration can move ingress paths or produce wrong user-facing links.
- Rollback: Revert commit `c16bccf` to restore the previous base-path behavior and root webhook route.

## RPIV Task
- Task: `github:49`
- Slice: S6y - Public application root and base-path ingress
- Branch: `feat/github-49-s6y-public-url`

## Human Review Checklist
- [x] Review changed files for repo conventions.
- [x] Confirm verification evidence is sufficient.
- [x] Confirm no secrets, local-only paths, or scratch artifacts are included.
