### PR TITLE
feat(ci): add Renovate workstream config and maintenance policy (#64)

### DIFF
--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -41,5 +41,5 @@ This document records the key architectural choices behind Nuecagram's design.
 
 - **Status**: Accepted
 - **Context**: Outdated dependencies create security risks, but unvetted auto-updates break builds.
-- **Decision**: Automate updates via Renovate with dependency grouping, security scanning (Trivy), and mandatory CI gate passing.
-- **Consequences**: Modern, secure dependencies with zero manual tracking overhead.
+- **Decision**: Automate updates via Renovate (`renovate.json5`) with dependency grouping (Kotlin/KSP, Ktor, Koin, Exposed, Flyway), security scanning (Trivy + Dependabot Alerts), and mandatory CI gate passing. Automerge is disabled.
+- **Consequences**: Modern, secure dependencies across Gradle, GitHub Actions, Docker, and Gradle Wrapper with zero manual tracking overhead. Policy details documented in `docs/architecture/dependency-maintenance.md`.

--- a/docs/architecture/dependency-maintenance.md
+++ b/docs/architecture/dependency-maintenance.md
@@ -1,0 +1,41 @@
+# Automated Dependency Maintenance Policy
+
+Nuecagram uses **Renovate** to manage dependency updates across all surface layers of the repository.
+
+## Policy Overview
+
+1. **Tooling**: Renovate is the sole bot for routine dependency-update PRs (`renovate.json5`).
+2. **Security Signals**: GitHub Dependency Graph and Dependabot Alerts provide security vulnerability detection. Dependabot version-update PRs are disabled to prevent duplicate bot activity.
+3. **Schedule**: Maintenance PRs run on a weekly schedule (`before 4am on Monday` in `Asia/Manila` timezone).
+4. **Automerge**: Disabled (`automerge: false`). All dependency PRs require human review and full CI pass.
+5. **Major Updates**: Major version updates remain separate and non-grouped for explicit review.
+
+## Dependency Surface Coverage
+
+- **Gradle Version Catalog**: `gradle/libs.versions.toml`
+- **Gradle Wrapper**: `gradle/wrapper/gradle-wrapper.properties`
+- **GitHub Actions Workflows**: `.github/workflows/*.yml`
+- **Dockerfile Base Images**: `Dockerfile`
+- **Docker Compose**: `compose.yaml` (Local container services)
+
+## Coordinated Dependency Grouping
+
+To prevent version skew across coupled libraries, Renovate groups updates into the following families:
+
+| Group Name | Match Pattern / Packages | Reason |
+|------------|-------------------------|--------|
+| `kotlin` | `org.jetbrains.kotlin.*`, `com.google.devtools.ksp` | Kotlin language, compiler plugins, and KSP must move together. |
+| `ktor` | `io.ktor:*` | Ktor server, client, and plugin dependencies share unified versioning. |
+| `koin` | `io.insert-koin:*` | Koin core, Ktor integration, slf4j logger, and annotations share compatibility. |
+| `exposed` | `org.jetbrains.exposed:*` | Exposed ORM core, JDBC, java-time, and JSON modules must match versions. |
+| `flyway` | `org.flywaydb:*` | Flyway core and database driver extensions must stay in sync. |
+
+*Note: `testBalloon` embeds the targeted Kotlin version in its artifact name (e.g. `1.0.1-K2.4.0`) and is updated individually with manual verification.*
+
+## Quality Gate Requirement
+
+Every Renovate PR must pass the exact same local and CI gate required for manual code changes:
+
+```bash
+./gradlew lintKotlinMain lintKotlinTest detekt test build
+```

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -7,4 +7,5 @@ Nuecagram is a self-hosted GitLab-to-Telegram notification gateway designed for 
 - [Core Principles](principles.md) — Fundamental architectural constraints and design philosophy.
 - [Feature-First Package Layout](feature-first.md) — Code organization, boundary mapping, and key components.
 - [Dependency & Import Rules](dependency-rules.md) — Direction of dependencies, layer isolation, and prohibited couplings.
+- [Automated Dependency Maintenance](dependency-maintenance.md) — Renovate policy, surface coverage, and grouping rules.
 - [Architectural Decisions](decisions.md) — Key design decisions and trade-offs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ Nuecagram hosts multiple GitLab project notification installs behind one Telegra
   - [Core Principles](architecture/principles.md)
   - [Feature-First Package Layout](architecture/feature-first.md)
   - [Dependency & Import Rules](architecture/dependency-rules.md)
+  - [Automated Dependency Maintenance](architecture/dependency-maintenance.md)
   - [Architectural Decisions](architecture/decisions.md)
 
 ## Guides

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "Asia/Manila",
+  "schedule": [
+    "before 4am on Monday"
+  ],
+  "dependencyDashboard": true,
+  "automerge": false,
+  "packageRules": [
+    {
+      "description": "Group Kotlin and KSP updates together",
+      "groupName": "kotlin",
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.kotlin/",
+        "/^com\\.google\\.devtools\\.ksp/"
+      ]
+    },
+    {
+      "description": "Group Ktor framework dependencies together",
+      "groupName": "ktor",
+      "matchPackageNames": [
+        "/^io\\.ktor:/"
+      ]
+    },
+    {
+      "description": "Group Koin DI dependencies together",
+      "groupName": "koin",
+      "matchPackageNames": [
+        "/^io\\.insert-koin:/"
+      ]
+    },
+    {
+      "description": "Group Exposed ORM dependencies together",
+      "groupName": "exposed",
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.exposed:/"
+      ]
+    },
+    {
+      "description": "Group Flyway database migration dependencies together",
+      "groupName": "flyway",
+      "matchPackageNames": [
+        "/^org\\.flywaydb:/"
+      ]
+    },
+    {
+      "description": "Keep major updates separate and non-automerged",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added root `renovate.json5` configuration for automated dependency maintenance with weekly schedule (Asia/Manila), automerge disabled, and dependency dashboard enabled.
- Configured package grouping rules for Kotlin/KSP, Ktor, Koin, Exposed, and Flyway families.
- Created `docs/architecture/dependency-maintenance.md` and updated ADR #6 in `decisions.md` to document policy, dependency surfaces, and quality gate requirements.

## Scope
- `renovate.json5`: Renovate base configuration and grouping rules.
- `docs/architecture/dependency-maintenance.md`: Detailed dependency maintenance documentation.
- `docs/architecture/decisions.md`: Updated ADR #6 with concrete implementation details.
- `docs/architecture/index.md` & `docs/index.md`: Linked new architecture document.

## Verification
- [x] `npx --yes --package=renovate@latest renovate-config-validator renovate.json5`
- [x] `test ! -e .github/dependabot.yml && test ! -e .github/dependabot.yaml`
- [x] `./gradlew lintKotlinMain lintKotlinTest detekt test build`
- [x] `./gradlew clean test`

## Risk / Rollback
- Risk: Low. Config and documentation changes only; no application code affected.
- Rollback: Revert commit `21e6f12` or remove `renovate.json5`.

## RPIV Task
- Task: `github:64`
- Slice: Parent workstream implementation (Slices 1-5: #68, #66, #69, #65, #67)
- Branch: `feat/64`

## Human Review Checklist
- [x] Review changed files for repo conventions.
- [x] Confirm verification evidence is sufficient.
- [x] Confirm no secrets, local-only paths, or scratch artifacts are included.
