### PR TITLE
feat(docs): document Telegram forum topic thread preservation

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,6 +41,10 @@ https://example.com/nuecagram -> http://127.0.0.1:8080/nuecagram
 
 Allow public traffic only to SSH, HTTP, and HTTPS as required. Production Compose binds the app to `127.0.0.1:8080`, so clients must use the reverse proxy.
 
+## Telegram topic thread preservation
+
+Nuecagram preserves Telegram Forum Topic thread IDs (`messageThreadId`). Slash commands typed inside a specific topic reply directly within that topic, and GitLab webhook installations bound to a topic post notifications exclusively into that topic.
+
 Suppress access logging for token-bearing paths, especially one-time management URLs. If full suppression is not possible, remove query strings and path parameters before writing logs.
 
 ## Secret handling


### PR DESCRIPTION
## Summary
- Added documentation for Telegram forum topic thread preservation and topic-bound webhook routing in .

## Verification
- [x] 
> Task :lintKotlinMain
lintKotlinMain is temporarily disabled.

> Task :lintKotlinTest
lintKotlinTest is temporarily disabled.

> Task :detekt
...........................................................

59 kotlin files were analyzed.
Complexity Report:
	- 9,031 lines of code (loc)
	- 7,997 source lines of code (sloc)
	- 6,559 logical lines of code (lloc)
	- 175 comment lines of code (cloc)
	- 918 cyclomatic complexity (mcc)
	- 391 cognitive complexity
	- 0 number of total code smells
	- 2% comment source ratio
	- 139 mcc per 1,000 lloc
	- 0 code smells per 1,000 lloc

Project Statistics:
	- number of properties: 751
	- number of functions: 349
	- number of classes: 80
	- number of packages: 7
	- number of kt files: 59


> Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :kspKotlin UP-TO-DATE
> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :jar UP-TO-DATE
> Task :shadowJar
> Task :kspTestKotlin SKIPPED
> Task :compileTestKotlin UP-TO-DATE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :test UP-TO-DATE
> Task :startScripts
> Task :distTar
> Task :distZip
> Task :startShadowScripts
> Task :shadowDistTar
> Task :shadowDistZip
> Task :assemble
> Task :check UP-TO-DATE
> Task :build

BUILD SUCCESSFUL in 6s
16 actionable tasks: 10 executed, 6 up-to-date (passed)
- [x] > Task :clean
> Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :kspKotlin
> Task :processResources
> Task :compileKotlin
> Task :compileJava NO-SOURCE
> Task :classes
> Task :jar
> Task :kspTestKotlin SKIPPED
> Task :processTestResources NO-SOURCE
> Task :compileTestKotlin
> Task :compileTestJava NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :test

BUILD SUCCESSFUL in 4s
7 actionable tasks: 7 executed (passed)