### PR TITLE
feat(docs): add Telegram forum topic routing guide

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,3 +6,4 @@ Practical step-by-step guides for extending Nuecagram during day-to-day developm
 
 - [Adding a New GitLab Event Type](add-event-type.md) — How to add support for a new GitLab webhook payload.
 - [Adding an External Infrastructure Adapter](add-adapter.md) — How to add a new external service interface, implementation, and DI wiring.
+- [Telegram Forum Topic Routing](telegram-topics.md) — How project webhooks bind to Telegram forum topics.

--- a/docs/guides/telegram-topics.md
+++ b/docs/guides/telegram-topics.md
@@ -1,0 +1,10 @@
+# Telegram Forum Topic Routing
+
+Nuecagram supports Telegram Supergroup Forum Topics out of the box.
+
+## How Topic Routing Works
+
+1. **Setup in Topic**: Run `/setup <gitlab-url> <project-id>` inside a specific Telegram topic.
+2. **Topic Binding**: Nuecagram stores `telegramTopicId` alongside `telegramChatId` in PostgreSQL.
+3. **Targeted Delivery**: Webhooks for that project post directly into that specific topic (`messageThreadId`) without touching General or other topics.
+4. **Preserved Command Replies**: Slash commands typed in a topic reply inside that same topic.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ Nuecagram hosts multiple GitLab project notification installs behind one Telegra
 - [Developer Guides Index](guides/index.md)
   - [Adding a New Event Type](guides/add-event-type.md)
   - [Adding an External Adapter](guides/add-adapter.md)
+  - [Telegram Forum Topic Routing](guides/telegram-topics.md)
 - [Onboarding](onboarding.md)
 - [Operations](operations.md)
 - [Webhook scripts](webhook-scripts.md)


### PR DESCRIPTION
## Summary
- Added developer guide for Telegram forum topic routing in .
- Linked new guide in  and .

## Verification
- [x] 
> Task :lintKotlinMain
lintKotlinMain is temporarily disabled.

> Task :lintKotlinTest
lintKotlinTest is temporarily disabled.

> Task :detekt
...........................................................

59 kotlin files were analyzed.
Complexity Report:
	- 9,031 lines of code (loc)
	- 7,997 source lines of code (sloc)
	- 6,559 logical lines of code (lloc)
	- 175 comment lines of code (cloc)
	- 918 cyclomatic complexity (mcc)
	- 391 cognitive complexity
	- 0 number of total code smells
	- 2% comment source ratio
	- 139 mcc per 1,000 lloc
	- 0 code smells per 1,000 lloc

Project Statistics:
	- number of properties: 751
	- number of functions: 349
	- number of classes: 80
	- number of packages: 7
	- number of kt files: 59


> Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :kspKotlin UP-TO-DATE
> Task :compileKotlin UP-TO-DATE
> Task :compileJava NO-SOURCE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :jar UP-TO-DATE
> Task :shadowJar
> Task :kspTestKotlin SKIPPED
> Task :compileTestKotlin UP-TO-DATE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :test UP-TO-DATE
> Task :startScripts
> Task :distTar
> Task :distZip
> Task :startShadowScripts
> Task :shadowDistTar
> Task :shadowDistZip
> Task :assemble
> Task :check UP-TO-DATE
> Task :build

BUILD SUCCESSFUL in 6s
16 actionable tasks: 10 executed, 6 up-to-date (passed)
- [x] > Task :clean
> Task :checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :kspKotlin
> Task :processResources
> Task :compileKotlin
> Task :compileJava NO-SOURCE
> Task :classes
> Task :jar
> Task :kspTestKotlin SKIPPED
> Task :processTestResources NO-SOURCE
> Task :compileTestKotlin
> Task :compileTestJava NO-SOURCE
> Task :testClasses UP-TO-DATE
> Task :test

BUILD SUCCESSFUL in 3s
7 actionable tasks: 7 executed (passed)