### PR TITLE
docs(agents): add branching rule and release suggestion protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,14 @@ For long answers, always include a **TLDR;** at the top.
 - If AI contributed to a commit, the commit message must include an exact `Assisted-by` trailer. Get the exact value with `bash ~/RQZ/personal/nothing/packages/workflows/norpiv/scripts/get-pi-model.sh` and use that exact output in the trailer, for example `Assisted-by: openai-codex:gpt-5.4 [read,bash,edit,write]`.
 - Before push, verify the actual committed trailer matches the current helper output; if not, amend the commit before pushing so `/verify` does not fail on trailer drift.
 
+## Branching & Release Management Protocol
+- **Zero Direct Push to `main`**: All code changes (features, bugfixes, docs, or version bumps) MUST be created on dedicated branches (`feat/...`, `fix/...`, `chore/...`) and merged via a Pull Request. Direct pushes to `main` are strictly prohibited.
+- **Automatic Issue Linking**: Every PR description MUST include explicit closing keywords (`Closes #<id>` or `Fixes #<id>`) to ensure GitHub automatically closes the corresponding issue upon merge.
+- **Proactive Release & Version Bump Suggestions**:
+  - After completing feature/fix slices, the agent MUST check if a version bump is needed (`patch` or `minor`).
+  - The agent MUST proactively suggest or create a release PR (`chore(release): bump version to x.y.z`) updating `version.txt` and `src/main/resources/version.txt`.
+  - Merging the release PR triggers the automated production deployment pipeline with the updated version string.
+
 ## Pull Request Standards (Open Source Specification)
 
 ### 1. PR Title Format


### PR DESCRIPTION
## Summary
- Added strict **Branching & Release Management Protocol** to `AGENTS.md`.
- Enforces 3 standard operating rules for future tasks:
  1. **Strict PR Workflow**: Zero direct pushes to `main`. Every change (feature, fix, chore, docs, version bump) MUST go through a feature/chore branch and PR.
  2. **Automated Issue Closing**: All PR descriptions MUST include `Closes #<id>` so GitHub automatically closes issues upon merge.
  3. **Proactive Release PR Suggestions**: After completing feature/fix slices, the agent MUST evaluate and suggest/create a version bump PR (`chore(release): bump version to x.y.z`) to keep `version.txt` in sync.

## Scope
- `AGENTS.md`

## Verification
- [x] `./gradlew lintKotlinMain lintKotlinTest`
- [x] `./gradlew detekt`
- [x] `./gradlew test`
- [x] `./gradlew build`

## Risk / Rollback
- Risk: Low; documentation and process guideline update only.
- Rollback: Revert commit `a064395`.

## Human Review Checklist
- [ ] Review changed files for repo conventions.
- [ ] Confirm verification evidence is sufficient.
- [ ] Confirm no secrets, local-only paths, or scratch artifacts are included.
