### PR TITLE
feat(telegram): add Telegram Web App initData validation and session auth foundation

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
@@ -247,7 +247,22 @@ class InstallationRepository(
             installationWithMuteQuery(installationId).firstOrNull()?.toAdminContext()
         }
 
+    suspend fun listInstallationsForContext(
+        chatId: Long?,
+        topicId: Long?,
+    ): List<InstallationAdminContext> = databaseFactory.dbTransaction {
+        val query = installationWithMuteQuery()
+        if (chatId != null) {
+            query.andWhere { Installations.telegramChatId eq chatId }
+            if (topicId != null) {
+                query.andWhere { Installations.telegramTopicId eq topicId }
+            }
+        }
+        query.map { it.toAdminContext() }
+    }
+
     suspend fun findInstallationByQuery(
+
         rawQuery: String,
         chatId: Long,
     ): InstallationAdminContext? = databaseFactory.dbTransaction {

--- a/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/db/InstallationRepository.kt
@@ -53,6 +53,32 @@ data class ManagementSessionContext(
 
 data class IssuedPlatformAdminSession(val id: UUID, val raw: String, val csrf: String)
 data class PlatformAdminSessionContext(val id: UUID, val csrfDigest: ByteArray, val csrfHash: String)
+
+data class IssuedWebAppSession(
+    val sessionId: UUID,
+    val telegramUserId: Long,
+    val telegramChatId: Long?,
+    val telegramTopicId: Long?,
+    val raw: String,
+    val csrf: String,
+)
+
+data class WebAppSessionContext(
+    val sessionId: UUID,
+    val telegramUserId: Long,
+    val telegramChatId: Long?,
+    val telegramTopicId: Long?,
+    val csrfDigest: ByteArray,
+    val csrfHash: String,
+)
+
+data class LaunchNonceContext(
+    val id: UUID,
+    val telegramChatId: Long,
+    val telegramTopicId: Long?,
+    val telegramUserId: Long,
+)
+
 data class PlatformAdminAuditRecord(val installationId: UUID?, val action: String, val createdAt: Instant)
 
 data class PlatformAdminInstallationsPage(
@@ -383,6 +409,108 @@ class InstallationRepository(
     suspend fun deletePlatformAdminSession(id: UUID): Boolean = databaseFactory.dbTransaction {
         PlatformAdminSessions.deleteWhere { PlatformAdminSessions.id eq id } == 1
     }
+
+    suspend fun issueLaunchNonce(
+        telegramChatId: Long,
+        telegramTopicId: Long?,
+        telegramUserId: Long,
+        expiresAt: Instant,
+    ): IssuedCredential = databaseFactory.dbTransaction {
+        val id = UUID.randomUUID()
+        val (raw, stored) = CredentialCodec.issueCredential()
+        TelegramLaunchNonces.insert {
+            it[TelegramLaunchNonces.id] = id
+            it[TelegramLaunchNonces.nonceDigest] = stored.digest
+            it[TelegramLaunchNonces.telegramChatId] = telegramChatId
+            it[TelegramLaunchNonces.telegramTopicId] = telegramTopicId
+            it[TelegramLaunchNonces.telegramUserId] = telegramUserId
+            it[TelegramLaunchNonces.expiresAt] = expiresAt.databaseTime()
+        }
+        IssuedCredential(id, id, raw)
+    }
+
+    suspend fun consumeLaunchNonce(
+        raw: String,
+        now: Instant = Instant.now(),
+    ): LaunchNonceContext? = databaseFactory.dbTransaction {
+        val databaseNow = now.databaseTime()
+        val row = TelegramLaunchNonces.selectAll().where {
+            TelegramLaunchNonces.consumedAt.isNull() and
+                (TelegramLaunchNonces.expiresAt greater databaseNow) and
+                (TelegramLaunchNonces.nonceDigest eq CredentialCodec.digest(raw))
+        }.firstOrNull() ?: return@dbTransaction null
+
+        val consumed = TelegramLaunchNonces.update({
+            (TelegramLaunchNonces.id eq row[TelegramLaunchNonces.id]) and TelegramLaunchNonces.consumedAt.isNull()
+        }) {
+            it[consumedAt] = databaseNow
+        } == 1
+
+        if (consumed) {
+            LaunchNonceContext(
+                id = row[TelegramLaunchNonces.id],
+                telegramChatId = row[TelegramLaunchNonces.telegramChatId],
+                telegramTopicId = row[TelegramLaunchNonces.telegramTopicId],
+                telegramUserId = row[TelegramLaunchNonces.telegramUserId],
+            )
+        } else null
+    }
+
+    suspend fun issueWebAppSession(
+        telegramUserId: Long,
+        telegramChatId: Long?,
+        telegramTopicId: Long?,
+        expiresAt: Instant,
+    ): IssuedWebAppSession = databaseFactory.dbTransaction {
+        val id = UUID.randomUUID()
+        val (raw, stored) = CredentialCodec.issueCredential()
+        val (csrf, storedCsrf) = CredentialCodec.issueCredential()
+        WebAppSessions.insert {
+            it[WebAppSessions.id] = id
+            it[WebAppSessions.telegramUserId] = telegramUserId
+            it[WebAppSessions.telegramChatId] = telegramChatId
+            it[WebAppSessions.telegramTopicId] = telegramTopicId
+            it[tokenDigest] = stored.digest
+            it[tokenHash] = stored.hash
+            it[csrfDigest] = storedCsrf.digest
+            it[csrfHash] = storedCsrf.hash
+            it[WebAppSessions.expiresAt] = expiresAt.databaseTime()
+        }
+        IssuedWebAppSession(id, telegramUserId, telegramChatId, telegramTopicId, raw, csrf)
+    }
+
+    suspend fun verifyWebAppSession(
+        raw: String,
+        now: Instant = Instant.now(),
+    ): WebAppSessionContext? = databaseFactory.dbTransaction {
+        WebAppSessions.selectAll().where {
+            (WebAppSessions.expiresAt greater now.databaseTime()) and
+                (WebAppSessions.tokenDigest eq CredentialCodec.digest(raw))
+        }.firstOrNull { row ->
+            CredentialCodec.matches(raw, row[WebAppSessions.tokenDigest], row[WebAppSessions.tokenHash])
+        }?.let { row ->
+            WebAppSessionContext(
+                sessionId = row[WebAppSessions.id],
+                telegramUserId = row[WebAppSessions.telegramUserId],
+                telegramChatId = row[WebAppSessions.telegramChatId],
+                telegramTopicId = row[WebAppSessions.telegramTopicId],
+                csrfDigest = row[WebAppSessions.csrfDigest],
+                csrfHash = row[WebAppSessions.csrfHash],
+            )
+        }
+    }
+
+    fun verifyWebAppCsrf(session: WebAppSessionContext, raw: String): Boolean =
+        CredentialCodec.matches(raw, session.csrfDigest, session.csrfHash)
+
+    suspend fun deleteWebAppSession(id: UUID): Boolean = databaseFactory.dbTransaction {
+        WebAppSessions.deleteWhere { WebAppSessions.id eq id } == 1
+    }
+
+    suspend fun cleanupExpiredWebAppSessions(now: Instant = Instant.now()): Int = databaseFactory.dbTransaction {
+        WebAppSessions.deleteWhere { WebAppSessions.expiresAt lessEq now.databaseTime() }
+    }
+
 
     suspend fun cleanupExpiredManagementLinks(now: Instant = Instant.now()): Int = databaseFactory.dbTransaction {
         ManagementLinks.deleteWhere { ManagementLinks.expiresAt lessEq now.databaseTime() }

--- a/src/main/kotlin/net/raquezha/nuecagram/db/Tables.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/db/Tables.kt
@@ -126,3 +126,32 @@ object MrParticipantCaches : Table("mr_participant_caches") {
 
     override val primaryKey = PrimaryKey(installationId, projectId, mrIid)
 }
+
+object TelegramLaunchNonces : Table("telegram_launch_nonces") {
+    val id = javaUUID("id")
+    val nonceDigest = binary("nonce_digest")
+    val telegramChatId = long("telegram_chat_id")
+    val telegramTopicId = long("telegram_topic_id").nullable()
+    val telegramUserId = long("telegram_user_id")
+    val expiresAt = timestampWithTimeZone("expires_at")
+    val consumedAt = timestampWithTimeZone("consumed_at").nullable()
+    val createdAt = timestampWithTimeZone("created_at").databaseGenerated()
+
+    override val primaryKey = PrimaryKey(id)
+}
+
+object WebAppSessions : Table("webapp_sessions") {
+    val id = javaUUID("id")
+    val telegramUserId = long("telegram_user_id")
+    val telegramChatId = long("telegram_chat_id").nullable()
+    val telegramTopicId = long("telegram_topic_id").nullable()
+    val tokenDigest = binary("token_digest")
+    val tokenHash = text("token_hash")
+    val csrfDigest = binary("csrf_digest")
+    val csrfHash = text("csrf_hash")
+    val expiresAt = timestampWithTimeZone("expires_at")
+    val createdAt = timestampWithTimeZone("created_at").databaseGenerated()
+
+    override val primaryKey = PrimaryKey(id)
+}
+

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/Routing.kt
@@ -79,6 +79,8 @@ fun Application.configureRouting() {
         telegramRouting(this@configureRouting.basePath())
         managementRouting(this@configureRouting.basePath())
         platformAdminRouting(this@configureRouting.basePath())
+        webAppRouting(this@configureRouting.basePath())
+
 
         post(configuredRoute("/webhook")) {
             try {
@@ -126,6 +128,8 @@ fun Application.configureRouting() {
                     installationRepository.cleanupExpiredManagementLinks()
                     installationRepository.cleanupExpiredManagementSessions()
                     installationRepository.cleanupExpiredPlatformAdminSessions()
+                    installationRepository.cleanupExpiredWebAppSessions()
+
                     logger.debug { "Periodic cleanup completed" }
                 } catch (e: Exception) {
                     logger.error(e) { "Periodic cleanup failed: ${e.message}" }

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
@@ -12,17 +12,25 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import net.raquezha.nuecagram.ConfigWithSecrets
+import net.raquezha.nuecagram.db.InstallationAdminContext
 import net.raquezha.nuecagram.db.InstallationRepository
+import net.raquezha.nuecagram.db.WebAppSessionContext
+import net.raquezha.nuecagram.telegram.Message
+import net.raquezha.nuecagram.telegram.TelegramService
 import net.raquezha.nuecagram.telegram.TelegramWebAppAuth
 import org.koin.ktor.ext.inject
 
 private const val WEBAPP_SESSION_COOKIE_NAME = "nuecagram_webapp_session"
 private const val WEBAPP_CSRF_COOKIE_NAME = "nuecagram_webapp_csrf"
+private const val CSRF_HEADER_NAME = "X-CSRF-Token"
 private const val SESSION_TTL_HOURS = 8L
 private const val SESSION_TTL_SECONDS = SESSION_TTL_HOURS * 60L * 60L
+private const val CONTAINER_MAX_WIDTH_PX = 480
+
 
 @Serializable
 private data class AuthRequestPayload(
@@ -47,12 +55,40 @@ private data class AuthResponsePayload(
 )
 
 @Serializable
+private data class InstallationResponsePayload(
+    val id: String,
+    val gitlabBaseUrl: String,
+    val gitlabProjectId: Long? = null,
+    val telegramChatId: Long,
+    val telegramTopicId: Long? = null,
+    val muted: Boolean,
+)
+
+@Serializable
+private data class MuteRequestPayload(
+    val muted: Boolean,
+)
+
+@Serializable
+private data class MuteResponsePayload(
+    val id: String,
+    val muted: Boolean,
+)
+
+@Serializable
+private data class TestResponsePayload(
+    val success: Boolean,
+    val message: String,
+)
+
+@Serializable
 private data class ErrorResponsePayload(
     val error: String,
 )
 
 fun Route.webAppRouting(basePath: String) {
     val installationRepository by inject<InstallationRepository>()
+    val telegramService by inject<TelegramService>()
     val config by inject<ConfigWithSecrets>()
     val json = Json { ignoreUnknownKeys = true }
 
@@ -67,6 +103,22 @@ fun Route.webAppRouting(basePath: String) {
 
     post("$basePath/api/webapp/auth") {
         call.handleWebAppAuth(installationRepository, config, json, basePath)
+    }
+
+    get("$basePath/api/webapp/installations") {
+        call.handleGetInstallations(installationRepository)
+    }
+
+    get("$basePath/api/webapp/installations/{id}") {
+        call.handleGetInstallationDetail(installationRepository)
+    }
+
+    post("$basePath/api/webapp/installations/{id}/mute") {
+        call.handleMuteInstallation(installationRepository, json)
+    }
+
+    post("$basePath/api/webapp/installations/{id}/test") {
+        call.handleTestInstallation(installationRepository, telegramService)
     }
 }
 
@@ -137,6 +189,149 @@ private suspend fun ApplicationCall.handleWebAppAuth(
     )
 }
 
+private suspend fun ApplicationCall.handleGetInstallations(
+    installationRepository: InstallationRepository,
+) {
+    val session = authenticateWebAppSession(installationRepository) ?: return
+    val reqChatId = parameters["chatId"]?.toLongOrNull() ?: session.telegramChatId
+    val reqTopicId = parameters["topicId"]?.toLongOrNull() ?: session.telegramTopicId
+
+    val items = installationRepository.listInstallationsForContext(reqChatId, reqTopicId)
+    appendWebAppSecurityHeaders()
+    respond(HttpStatusCode.OK, items.map { it.toResponsePayload() })
+}
+
+private suspend fun ApplicationCall.handleGetInstallationDetail(
+    installationRepository: InstallationRepository,
+) {
+    authenticateWebAppSession(installationRepository) ?: return
+    val idParam = parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+    if (idParam == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponsePayload("Invalid installation ID"))
+        return
+    }
+
+    val item = installationRepository.installationAdminContext(idParam)
+    if (item == null) {
+        respond(HttpStatusCode.NotFound, ErrorResponsePayload("Installation not found"))
+        return
+    }
+
+    appendWebAppSecurityHeaders()
+    respond(HttpStatusCode.OK, item.toResponsePayload())
+}
+
+private suspend fun ApplicationCall.handleMuteInstallation(
+    installationRepository: InstallationRepository,
+    json: Json,
+) {
+    val session = authenticateWebAppSession(installationRepository) ?: return
+    if (!verifyCsrfHeader(installationRepository, session)) return
+
+    val idParam = parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+    if (idParam == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponsePayload("Invalid installation ID"))
+        return
+    }
+
+    val item = installationRepository.installationAdminContext(idParam)
+    if (item == null) {
+        respond(HttpStatusCode.NotFound, ErrorResponsePayload("Installation not found"))
+        return
+    }
+
+    val bodyText = receiveText()
+    val reqPayload = runCatching { json.decodeFromString<MuteRequestPayload>(bodyText) }.getOrNull()
+    val targetMuted = reqPayload?.muted ?: !item.muted
+
+    installationRepository.setMuted(item.id, targetMuted)
+    installationRepository.writeAuditEvent(
+        installationId = item.id,
+        actorType = "webapp_session",
+        actorId = session.sessionId.toString(),
+        action = if (targetMuted) "webapp_mute" else "webapp_unmute",
+    )
+
+    appendWebAppSecurityHeaders()
+    respond(HttpStatusCode.OK, MuteResponsePayload(id = item.id.toString(), muted = targetMuted))
+}
+
+private suspend fun ApplicationCall.handleTestInstallation(
+    installationRepository: InstallationRepository,
+    telegramService: TelegramService,
+) {
+    val session = authenticateWebAppSession(installationRepository) ?: return
+    if (!verifyCsrfHeader(installationRepository, session)) return
+
+    val idParam = parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
+    if (idParam == null) {
+        respond(HttpStatusCode.BadRequest, ErrorResponsePayload("Invalid installation ID"))
+        return
+    }
+
+    val item = installationRepository.installationAdminContext(idParam)
+    if (item == null) {
+        respond(HttpStatusCode.NotFound, ErrorResponsePayload("Installation not found"))
+        return
+    }
+
+    telegramService.sendMessage(
+        Message(
+            chatId = item.telegramChatId.toString(),
+            text = "Nuecagram delivery test for installation ${item.id}.",
+            threadId = item.telegramTopicId,
+        ),
+    )
+
+    installationRepository.writeAuditEvent(
+        installationId = item.id,
+        actorType = "webapp_session",
+        actorId = session.sessionId.toString(),
+        action = "webapp_test",
+    )
+
+    appendWebAppSecurityHeaders()
+    respond(HttpStatusCode.OK, TestResponsePayload(success = true, message = "Test delivery dispatched."))
+}
+
+private suspend fun ApplicationCall.authenticateWebAppSession(
+    installationRepository: InstallationRepository,
+): WebAppSessionContext? {
+    val sessionCookie = request.cookies[WEBAPP_SESSION_COOKIE_NAME]?.takeIf(String::isNotBlank)
+    if (sessionCookie == null) {
+        respond(HttpStatusCode.Unauthorized, ErrorResponsePayload("Web App session required"))
+        return null
+    }
+
+    val session = installationRepository.verifyWebAppSession(sessionCookie)
+    if (session == null) {
+        respond(HttpStatusCode.Unauthorized, ErrorResponsePayload("Session expired or invalid"))
+        return null
+    }
+    return session
+}
+
+private suspend fun ApplicationCall.verifyCsrfHeader(
+    installationRepository: InstallationRepository,
+    session: WebAppSessionContext,
+): Boolean {
+    val csrfHeader = request.headers[CSRF_HEADER_NAME].orEmpty()
+    if (!installationRepository.verifyWebAppCsrf(session, csrfHeader)) {
+        respond(HttpStatusCode.Forbidden, ErrorResponsePayload("Invalid CSRF token"))
+        return false
+    }
+    return true
+}
+
+private fun InstallationAdminContext.toResponsePayload() = InstallationResponsePayload(
+    id = id.toString(),
+    gitlabBaseUrl = gitlabBaseUrl,
+    gitlabProjectId = gitlabProjectId,
+    telegramChatId = telegramChatId,
+    telegramTopicId = telegramTopicId,
+    muted = muted,
+)
+
 internal fun ApplicationCall.appendWebAppSecurityHeaders() {
     response.headers.append("Cache-Control", "no-store, no-cache, must-revalidate")
     response.headers.append("Pragma", "no-cache")
@@ -169,6 +364,7 @@ private fun buildCookie(
         if (secure) append("; Secure")
     }
 
+@Suppress("LongMethod", "MagicNumber")
 private fun webAppShellHtml(basePath: String): String = """
 <!doctype html>
 <html lang="en">
@@ -176,23 +372,134 @@ private fun webAppShellHtml(basePath: String): String = """
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Nuecagram Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Reddit+Mono:wght@400;600&family=Space+Grotesk:wght@500;700&display=swap" rel="stylesheet">
     <script src="https://telegram.org/js/telegram-web-app.js"></script>
     <style>
-      body { font-family: sans-serif; background: #eee4d5; color: #2c251e; margin: 0; padding: 1rem; }
-      .card { background: #fff; padding: 1rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+      :root {
+        --bg-color: #eee4d5;
+        --card-bg: rgba(255, 255, 255, 0.92);
+        --card-border: #dfd5c6;
+        --text-main: #2c251e;
+        --accent-tg: #229ed9;
+        --success: #2a684d;
+        --danger: #a62b1e;
+        --code-bg: #eae1d5;
+        --font-grotesk: 'Space Grotesk', sans-serif;
+        --font-mono: 'Reddit Mono', monospace;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; padding: 1rem;
+        background-color: var(--bg-color);
+        font-family: var(--font-mono);
+        color: var(--text-main);
+      }
+      .container { max-width: ${CONTAINER_MAX_WIDTH_PX}px; margin: 0 auto; }
+      .context-banner {
+        background: var(--code-bg); padding: 0.75rem 1rem; border-radius: 8px;
+        margin-bottom: 1rem; border: 1px solid var(--card-border); font-size: 0.85rem;
+      }
+      .card {
+        background: var(--card-bg); border: 1px solid var(--card-border);
+        border-radius: 12px; padding: 1rem; margin-bottom: 1rem;
+      }
+      .card-header { display: flex; justify-content: space-between; align-items: center; }
+      .card-id { font-weight: 700; font-family: var(--font-grotesk); }
+      .badge { padding: 0.2rem 0.6rem; border-radius: 999px; font-size: 0.75rem; font-weight: 700; }
+      .badge-active { background: #e6f4ea; color: var(--success); }
+      .badge-muted { background: #fff5f5; color: var(--danger); }
+      .actions { display: flex; gap: 0.5rem; margin-top: 0.85rem; }
+      button {
+        font-family: var(--font-grotesk); font-weight: 600; font-size: 0.85rem;
+        padding: 0.4rem 0.8rem; border-radius: 6px; border: 1px solid var(--card-border);
+        background: #fff; cursor: pointer;
+      }
     </style>
   </head>
   <body>
-    <div id="app" class="card">
-      <h2>Nuecagram Management</h2>
-      <p id="status">Initializing Telegram WebApp...</p>
+    <div class="container">
+      <div id="contextBanner" class="context-banner">
+        <strong>Context:</strong> <span id="contextText">Resolving Telegram context...</span>
+      </div>
+      <div id="installationsList">
+        <div class="card"><p>Loading installations...</p></div>
+      </div>
     </div>
     <script>
-      if (window.Telegram && window.Telegram.WebApp) {
-        window.Telegram.WebApp.ready();
-        window.Telegram.WebApp.expand();
-        document.getElementById('status').innerText = 'Telegram WebApp initialized.';
+      let userCsrf = '';
+
+      async function initWebApp() {
+        if (window.Telegram && window.Telegram.WebApp) {
+          window.Telegram.WebApp.ready();
+          window.Telegram.WebApp.expand();
+        }
+        const tgInitData = (window.Telegram && window.Telegram.WebApp && window.Telegram.WebApp.initData) || '';
+        try {
+          const res = await fetch('${basePath}/api/webapp/auth', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ initData: tgInitData })
+          });
+          if (res.ok) {
+            const data = await res.json();
+            userCsrf = data.csrf;
+            document.getElementById('contextText').innerText = data.telegramChatId
+              ? 'Chat #' + data.telegramChatId + (data.telegramTopicId ? ' (Topic #' + data.telegramTopicId + ')' : '')
+              : 'All Accessible Installations';
+            await loadInstallations();
+          } else {
+            document.getElementById('contextText').innerText = 'Authentication required.';
+          }
+        } catch (e) {
+          document.getElementById('contextText').innerText = 'Error connecting to server.';
+        }
       }
+
+      async function loadInstallations() {
+        const res = await fetch('${basePath}/api/webapp/installations');
+        if (!res.ok) return;
+        const items = await res.json();
+        const el = document.getElementById('installationsList');
+        if (items.length === 0) {
+          el.innerHTML = '<div class="card"><p>No installations found for this context.</p></div>';
+          return;
+        }
+        el.innerHTML = items.map(function(item) {
+          var statusBadge = item.muted ? '<span class="badge badge-muted">Muted</span>' : '<span class="badge badge-active">Active</span>';
+          var muteText = item.muted ? 'Unmute' : 'Mute';
+          return '<div class="card">' +
+            '<div class="card-header">' +
+            '<span class="card-id">' + item.id.substring(0, 8) + '</span>' +
+            statusBadge +
+            '</div>' +
+            '<p style="margin: 0.5rem 0 0.25rem; font-size: 0.85rem;">GitLab: ' + item.gitlabBaseUrl + '</p>' +
+            '<div class="actions">' +
+            '<button onclick="testDelivery('' + item.id + '')">Test</button>' +
+            '<button onclick="toggleMute('' + item.id + '', ' + (!item.muted) + ')">' + muteText + '</button>' +
+            '</div>' +
+            '</div>';
+        }).join('');
+      }
+
+      async function toggleMute(id, muted) {
+        await fetch('${basePath}/api/webapp/installations/' + id + '/mute', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': userCsrf },
+          body: JSON.stringify({ muted: muted })
+        });
+        await loadInstallations();
+      }
+
+      async function testDelivery(id) {
+        await fetch('${basePath}/api/webapp/installations/' + id + '/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': userCsrf }
+        });
+      }
+
+      initWebApp();
     </script>
   </body>
 </html>

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
@@ -30,7 +30,7 @@ private const val CSRF_HEADER_NAME = "X-CSRF-Token"
 private const val SESSION_TTL_HOURS = 8L
 private const val SESSION_TTL_SECONDS = SESSION_TTL_HOURS * 60L * 60L
 private const val CONTAINER_MAX_WIDTH_PX = 480
-
+private val ADMIN_STATUSES = setOf("creator", "administrator")
 
 @Serializable
 private data class AuthRequestPayload(
@@ -101,20 +101,29 @@ fun Route.webAppRouting(basePath: String) {
         )
     }
 
+    get("$basePath/webapp/app.js") {
+        call.appendWebAppSecurityHeaders()
+        call.respondText(
+            webAppJsScript(basePath),
+            ContentType.Text.JavaScript,
+            HttpStatusCode.OK,
+        )
+    }
+
     post("$basePath/api/webapp/auth") {
         call.handleWebAppAuth(installationRepository, config, json, basePath)
     }
 
     get("$basePath/api/webapp/installations") {
-        call.handleGetInstallations(installationRepository)
+        call.handleGetInstallations(installationRepository, telegramService)
     }
 
     get("$basePath/api/webapp/installations/{id}") {
-        call.handleGetInstallationDetail(installationRepository)
+        call.handleGetInstallationDetail(installationRepository, telegramService)
     }
 
     post("$basePath/api/webapp/installations/{id}/mute") {
-        call.handleMuteInstallation(installationRepository, json)
+        call.handleMuteInstallation(installationRepository, telegramService, json)
     }
 
     post("$basePath/api/webapp/installations/{id}/test") {
@@ -191,20 +200,29 @@ private suspend fun ApplicationCall.handleWebAppAuth(
 
 private suspend fun ApplicationCall.handleGetInstallations(
     installationRepository: InstallationRepository,
+    telegramService: TelegramService,
 ) {
     val session = authenticateWebAppSession(installationRepository) ?: return
-    val reqChatId = parameters["chatId"]?.toLongOrNull() ?: session.telegramChatId
-    val reqTopicId = parameters["topicId"]?.toLongOrNull() ?: session.telegramTopicId
+    if (!verifyAdminStatus(session, telegramService)) return
 
-    val items = installationRepository.listInstallationsForContext(reqChatId, reqTopicId)
+    if (session.telegramChatId == null) {
+        appendWebAppSecurityHeaders()
+        respond(HttpStatusCode.OK, emptyList<InstallationResponsePayload>())
+        return
+    }
+
+    val items = installationRepository.listInstallationsForContext(session.telegramChatId, session.telegramTopicId)
     appendWebAppSecurityHeaders()
     respond(HttpStatusCode.OK, items.map { it.toResponsePayload() })
 }
 
 private suspend fun ApplicationCall.handleGetInstallationDetail(
     installationRepository: InstallationRepository,
+    telegramService: TelegramService,
 ) {
-    authenticateWebAppSession(installationRepository) ?: return
+    val session = authenticateWebAppSession(installationRepository) ?: return
+    if (!verifyAdminStatus(session, telegramService)) return
+
     val idParam = parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
     if (idParam == null) {
         respond(HttpStatusCode.BadRequest, ErrorResponsePayload("Invalid installation ID"))
@@ -212,7 +230,7 @@ private suspend fun ApplicationCall.handleGetInstallationDetail(
     }
 
     val item = installationRepository.installationAdminContext(idParam)
-    if (item == null) {
+    if (item == null || !session.canAccess(item)) {
         respond(HttpStatusCode.NotFound, ErrorResponsePayload("Installation not found"))
         return
     }
@@ -223,9 +241,11 @@ private suspend fun ApplicationCall.handleGetInstallationDetail(
 
 private suspend fun ApplicationCall.handleMuteInstallation(
     installationRepository: InstallationRepository,
+    telegramService: TelegramService,
     json: Json,
 ) {
     val session = authenticateWebAppSession(installationRepository) ?: return
+    if (!verifyAdminStatus(session, telegramService)) return
     if (!verifyCsrfHeader(installationRepository, session)) return
 
     val idParam = parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
@@ -235,7 +255,7 @@ private suspend fun ApplicationCall.handleMuteInstallation(
     }
 
     val item = installationRepository.installationAdminContext(idParam)
-    if (item == null) {
+    if (item == null || !session.canAccess(item)) {
         respond(HttpStatusCode.NotFound, ErrorResponsePayload("Installation not found"))
         return
     }
@@ -248,7 +268,7 @@ private suspend fun ApplicationCall.handleMuteInstallation(
     installationRepository.writeAuditEvent(
         installationId = item.id,
         actorType = "webapp_session",
-        actorId = session.sessionId.toString(),
+        actorId = session.telegramUserId.toString(),
         action = if (targetMuted) "webapp_mute" else "webapp_unmute",
     )
 
@@ -261,6 +281,7 @@ private suspend fun ApplicationCall.handleTestInstallation(
     telegramService: TelegramService,
 ) {
     val session = authenticateWebAppSession(installationRepository) ?: return
+    if (!verifyAdminStatus(session, telegramService)) return
     if (!verifyCsrfHeader(installationRepository, session)) return
 
     val idParam = parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
@@ -270,7 +291,7 @@ private suspend fun ApplicationCall.handleTestInstallation(
     }
 
     val item = installationRepository.installationAdminContext(idParam)
-    if (item == null) {
+    if (item == null || !session.canAccess(item)) {
         respond(HttpStatusCode.NotFound, ErrorResponsePayload("Installation not found"))
         return
     }
@@ -286,12 +307,32 @@ private suspend fun ApplicationCall.handleTestInstallation(
     installationRepository.writeAuditEvent(
         installationId = item.id,
         actorType = "webapp_session",
-        actorId = session.sessionId.toString(),
+        actorId = session.telegramUserId.toString(),
         action = "webapp_test",
     )
 
     appendWebAppSecurityHeaders()
     respond(HttpStatusCode.OK, TestResponsePayload(success = true, message = "Test delivery dispatched."))
+}
+
+private fun WebAppSessionContext.canAccess(item: InstallationAdminContext): Boolean {
+    if (telegramChatId == null) return false
+    if (item.telegramChatId != telegramChatId) return false
+    if (telegramTopicId != null && item.telegramTopicId != telegramTopicId) return false
+    return true
+}
+
+private suspend fun ApplicationCall.verifyAdminStatus(
+    session: WebAppSessionContext,
+    telegramService: TelegramService,
+): Boolean {
+    val chatId = session.telegramChatId ?: return true
+    val status = runCatching { telegramService.chatMemberStatus(chatId, session.telegramUserId) }.getOrNull()
+    if (status !in ADMIN_STATUSES) {
+        respond(HttpStatusCode.Forbidden, ErrorResponsePayload("Telegram group administrator permissions required"))
+        return false
+    }
+    return true
 }
 
 private suspend fun ApplicationCall.authenticateWebAppSession(
@@ -427,80 +468,84 @@ private fun webAppShellHtml(basePath: String): String = """
         <div class="card"><p>Loading installations...</p></div>
       </div>
     </div>
-    <script>
-      let userCsrf = '';
-
-      async function initWebApp() {
-        if (window.Telegram && window.Telegram.WebApp) {
-          window.Telegram.WebApp.ready();
-          window.Telegram.WebApp.expand();
-        }
-        const tgInitData = (window.Telegram && window.Telegram.WebApp && window.Telegram.WebApp.initData) || '';
-        try {
-          const res = await fetch('${basePath}/api/webapp/auth', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ initData: tgInitData })
-          });
-          if (res.ok) {
-            const data = await res.json();
-            userCsrf = data.csrf;
-            document.getElementById('contextText').innerText = data.telegramChatId
-              ? 'Chat #' + data.telegramChatId + (data.telegramTopicId ? ' (Topic #' + data.telegramTopicId + ')' : '')
-              : 'All Accessible Installations';
-            await loadInstallations();
-          } else {
-            document.getElementById('contextText').innerText = 'Authentication required.';
-          }
-        } catch (e) {
-          document.getElementById('contextText').innerText = 'Error connecting to server.';
-        }
-      }
-
-      async function loadInstallations() {
-        const res = await fetch('${basePath}/api/webapp/installations');
-        if (!res.ok) return;
-        const items = await res.json();
-        const el = document.getElementById('installationsList');
-        if (items.length === 0) {
-          el.innerHTML = '<div class="card"><p>No installations found for this context.</p></div>';
-          return;
-        }
-        el.innerHTML = items.map(function(item) {
-          var statusBadge = item.muted ? '<span class="badge badge-muted">Muted</span>' : '<span class="badge badge-active">Active</span>';
-          var muteText = item.muted ? 'Unmute' : 'Mute';
-          return '<div class="card">' +
-            '<div class="card-header">' +
-            '<span class="card-id">' + item.id.substring(0, 8) + '</span>' +
-            statusBadge +
-            '</div>' +
-            '<p style="margin: 0.5rem 0 0.25rem; font-size: 0.85rem;">GitLab: ' + item.gitlabBaseUrl + '</p>' +
-            '<div class="actions">' +
-            '<button onclick="testDelivery('' + item.id + '')">Test</button>' +
-            '<button onclick="toggleMute('' + item.id + '', ' + (!item.muted) + ')">' + muteText + '</button>' +
-            '</div>' +
-            '</div>';
-        }).join('');
-      }
-
-      async function toggleMute(id, muted) {
-        await fetch('${basePath}/api/webapp/installations/' + id + '/mute', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': userCsrf },
-          body: JSON.stringify({ muted: muted })
-        });
-        await loadInstallations();
-      }
-
-      async function testDelivery(id) {
-        await fetch('${basePath}/api/webapp/installations/' + id + '/test', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': userCsrf }
-        });
-      }
-
-      initWebApp();
-    </script>
+    <script src="${basePath}/webapp/app.js"></script>
   </body>
 </html>
+""".trimIndent()
+
+@Suppress("LongMethod", "MagicNumber")
+private fun webAppJsScript(basePath: String): String = """
+let userCsrf = '';
+
+async function initWebApp() {
+  if (window.Telegram && window.Telegram.WebApp) {
+    window.Telegram.WebApp.ready();
+    window.Telegram.WebApp.expand();
+  }
+  const tgInitData = (window.Telegram && window.Telegram.WebApp && window.Telegram.WebApp.initData) || '';
+  try {
+    const res = await fetch('${basePath}/api/webapp/auth', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ initData: tgInitData })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      userCsrf = data.csrf;
+      document.getElementById('contextText').innerText = data.telegramChatId
+        ? 'Chat #' + data.telegramChatId + (data.telegramTopicId ? ' (Topic #' + data.telegramTopicId + ')' : '')
+        : 'All Accessible Installations';
+      await loadInstallations();
+    } else {
+      document.getElementById('contextText').innerText = 'Authentication required.';
+    }
+  } catch (e) {
+    document.getElementById('contextText').innerText = 'Error connecting to server.';
+  }
+}
+
+async function loadInstallations() {
+  const res = await fetch('${basePath}/api/webapp/installations');
+  if (!res.ok) return;
+  const items = await res.json();
+  const el = document.getElementById('installationsList');
+  if (items.length === 0) {
+    el.innerHTML = '<div class="card"><p>No installations found for this context.</p></div>';
+    return;
+  }
+  el.innerHTML = '';
+  items.forEach(function(item) {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const statusBadge = item.muted ? '<span class="badge badge-muted">Muted</span>' : '<span class="badge badge-active">Active</span>';
+    card.innerHTML = '<div class="card-header"><span class="card-id">' + item.id.substring(0, 8) + '</span>' + statusBadge + '</div>' +
+      '<p style="margin: 0.5rem 0 0.25rem; font-size: 0.85rem;">GitLab: ' + item.gitlabBaseUrl + '</p>' +
+      '<div class="actions">' +
+      '<button class="btn-test">Test</button>' +
+      '<button class="btn-mute">' + (item.muted ? 'Unmute' : 'Mute') + '</button>' +
+      '</div>';
+    
+    card.querySelector('.btn-test').addEventListener('click', function() { testDelivery(item.id); });
+    card.querySelector('.btn-mute').addEventListener('click', function() { toggleMute(item.id, !item.muted); });
+    el.appendChild(card);
+  });
+}
+
+async function toggleMute(id, muted) {
+  await fetch('${basePath}/api/webapp/installations/' + id + '/mute', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': userCsrf },
+    body: JSON.stringify({ muted: muted })
+  });
+  await loadInstallations();
+}
+
+async function testDelivery(id) {
+  await fetch('${basePath}/api/webapp/installations/' + id + '/test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': userCsrf }
+  });
+}
+
+initWebApp();
 """.trimIndent()

--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
@@ -1,0 +1,199 @@
+package net.raquezha.nuecagram.plugins
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveText
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import net.raquezha.nuecagram.ConfigWithSecrets
+import net.raquezha.nuecagram.db.InstallationRepository
+import net.raquezha.nuecagram.telegram.TelegramWebAppAuth
+import org.koin.ktor.ext.inject
+
+private const val WEBAPP_SESSION_COOKIE_NAME = "nuecagram_webapp_session"
+private const val WEBAPP_CSRF_COOKIE_NAME = "nuecagram_webapp_csrf"
+private const val SESSION_TTL_HOURS = 8L
+private const val SESSION_TTL_SECONDS = SESSION_TTL_HOURS * 60L * 60L
+
+@Serializable
+private data class AuthRequestPayload(
+    val initData: String,
+    val startParam: String? = null,
+)
+
+@Serializable
+private data class AuthResponseUser(
+    val id: Long,
+    val firstName: String? = null,
+    val username: String? = null,
+)
+
+@Serializable
+private data class AuthResponsePayload(
+    val success: Boolean,
+    val user: AuthResponseUser,
+    val csrf: String,
+    val telegramChatId: Long? = null,
+    val telegramTopicId: Long? = null,
+)
+
+@Serializable
+private data class ErrorResponsePayload(
+    val error: String,
+)
+
+fun Route.webAppRouting(basePath: String) {
+    val installationRepository by inject<InstallationRepository>()
+    val config by inject<ConfigWithSecrets>()
+    val json = Json { ignoreUnknownKeys = true }
+
+    get("$basePath/webapp") {
+        call.appendWebAppSecurityHeaders()
+        call.respondText(
+            webAppShellHtml(basePath),
+            ContentType.Text.Html,
+            HttpStatusCode.OK,
+        )
+    }
+
+    post("$basePath/api/webapp/auth") {
+        call.handleWebAppAuth(installationRepository, config, json, basePath)
+    }
+}
+
+@Suppress("LongMethod")
+private suspend fun ApplicationCall.handleWebAppAuth(
+    installationRepository: InstallationRepository,
+    config: ConfigWithSecrets,
+    json: Json,
+    basePath: String,
+) {
+    val bodyText = receiveText()
+    val payload = runCatching { json.decodeFromString<AuthRequestPayload>(bodyText) }.getOrNull()
+    if (payload == null || payload.initData.isBlank()) {
+        respond(HttpStatusCode.BadRequest, ErrorResponsePayload("Missing initData payload"))
+        return
+    }
+
+    val verified = TelegramWebAppAuth.verifyInitData(payload.initData, config.botApi)
+    if (verified == null) {
+        respond(HttpStatusCode.Unauthorized, ErrorResponsePayload("Invalid or expired initData signature"))
+        return
+    }
+
+    var resolvedChatId: Long? = null
+    var resolvedTopicId: Long? = null
+
+    val startParam = payload.startParam ?: verified.startParam
+    if (!startParam.isNullOrBlank() && startParam.startsWith("nonce_")) {
+        val rawNonce = startParam.removePrefix("nonce_")
+        val nonceCtx = installationRepository.consumeLaunchNonce(rawNonce)
+        if (nonceCtx != null && nonceCtx.telegramUserId == verified.user.id) {
+            resolvedChatId = nonceCtx.telegramChatId
+            resolvedTopicId = nonceCtx.telegramTopicId
+        }
+    }
+
+    val sessionExpiry = Instant.now().plus(SESSION_TTL_HOURS, ChronoUnit.HOURS)
+    val session = installationRepository.issueWebAppSession(
+        telegramUserId = verified.user.id,
+        telegramChatId = resolvedChatId,
+        telegramTopicId = resolvedTopicId,
+        expiresAt = sessionExpiry,
+    )
+
+    response.headers.append(
+        HttpHeaders.SetCookie,
+        buildCookie(WEBAPP_SESSION_COOKIE_NAME, session.raw, basePath, SESSION_TTL_SECONDS, isHttps()),
+    )
+    response.headers.append(
+        HttpHeaders.SetCookie,
+        buildCookie(WEBAPP_CSRF_COOKIE_NAME, session.csrf, basePath, SESSION_TTL_SECONDS, isHttps()),
+    )
+
+    appendWebAppSecurityHeaders()
+    respond(
+        HttpStatusCode.OK,
+        AuthResponsePayload(
+            success = true,
+            user = AuthResponseUser(
+                id = verified.user.id,
+                firstName = verified.user.firstName,
+                username = verified.user.username,
+            ),
+            csrf = session.csrf,
+            telegramChatId = resolvedChatId,
+            telegramTopicId = resolvedTopicId,
+        ),
+    )
+}
+
+internal fun ApplicationCall.appendWebAppSecurityHeaders() {
+    response.headers.append("Cache-Control", "no-store, no-cache, must-revalidate")
+    response.headers.append("Pragma", "no-cache")
+    response.headers.append("Referrer-Policy", "no-referrer")
+    response.headers.append("X-Frame-Options", "DENY")
+    response.headers.append("X-Content-Type-Options", "nosniff")
+    response.headers.append(
+        "Content-Security-Policy",
+        "default-src 'self'; script-src 'self' https://telegram.org; " +
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+            "font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-ancestors 'none'",
+    )
+    if (isHttps()) {
+        response.headers.append(
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains",
+        )
+    }
+}
+
+private fun buildCookie(
+    name: String,
+    value: String,
+    basePath: String,
+    maxAge: Long,
+    secure: Boolean,
+): String =
+    buildString {
+        append("$name=$value; Path=$basePath; Max-Age=$maxAge; HttpOnly; SameSite=Strict")
+        if (secure) append("; Secure")
+    }
+
+private fun webAppShellHtml(basePath: String): String = """
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Nuecagram Management</title>
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
+    <style>
+      body { font-family: sans-serif; background: #eee4d5; color: #2c251e; margin: 0; padding: 1rem; }
+      .card { background: #fff; padding: 1rem; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    </style>
+  </head>
+  <body>
+    <div id="app" class="card">
+      <h2>Nuecagram Management</h2>
+      <p id="status">Initializing Telegram WebApp...</p>
+    </div>
+    <script>
+      if (window.Telegram && window.Telegram.WebApp) {
+        window.Telegram.WebApp.ready();
+        window.Telegram.WebApp.expand();
+        document.getElementById('status').innerText = 'Telegram WebApp initialized.';
+      }
+    </script>
+  </body>
+</html>
+""".trimIndent()

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
@@ -49,6 +49,7 @@ private const val SETUP_ARG_COUNT_MIN = 3
 private const val SETUP_ARG_COUNT_MAX = 3
 private const val SETUP_URL_INDEX = 1
 private const val SETUP_PROJECT_INDEX = 2
+private const val LAUNCH_NONCE_TTL_MINUTES = 10L
 
 private data class AuthorizedGroupAdmin(
     val actorId: Long,
@@ -66,6 +67,7 @@ private data class SetupArguments(
     val projectId: Long,
 )
 
+@Suppress("TooManyFunctions")
 class TelegramUpdateHandler(
     private val installationRepository: InstallationRepository,
     private val telegramService: TelegramService,
@@ -100,6 +102,7 @@ class TelegramUpdateHandler(
             "/unmute" -> handleUnmute(message)
             "/setup" -> handleSetup(message)
             "/manage" -> handleManage(message)
+            "/webapp" -> handleWebApp(message)
             "/rotate" -> handleRotate(message)
             else ->
                 if (command.startsWith("/")) {
@@ -214,6 +217,28 @@ class TelegramUpdateHandler(
             managementLinkText(config, authorized.installation.id, managementLink.raw),
         )
         send(message.chat.id, PRIVATE_DELIVERY_MESSAGE, message.messageThreadId)
+    }
+
+    private suspend fun handleWebApp(message: TelegramMessage) {
+        val groupAdmin = authorizeGroupAdmin(message, "Usage: <code>/webapp</code>") ?: return
+        val nonce = installationRepository.issueLaunchNonce(
+            telegramChatId = message.chat.id,
+            telegramTopicId = message.messageThreadId,
+            telegramUserId = groupAdmin.actorId,
+            expiresAt = Instant.now().plus(LAUNCH_NONCE_TTL_MINUTES, ChronoUnit.MINUTES),
+        )
+        installationRepository.writeAuditEvent(
+            installationId = null,
+            actorType = "telegram",
+            actorId = groupAdmin.actorId.toString(),
+            action = "telegram_webapp_launch",
+        )
+        val webAppUrl = "${config.publicBaseUrl()}/webapp?startapp=nonce_${nonce.raw}"
+        send(
+            message.chat.id,
+            "Open Nuecagram Web App:\n$webAppUrl",
+            message.messageThreadId,
+        )
     }
 
     private suspend fun handleRotate(message: TelegramMessage) {

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramWebAppAuth.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramWebAppAuth.kt
@@ -1,0 +1,106 @@
+package net.raquezha.nuecagram.telegram
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+private const val MAX_AUTH_AGE_SECONDS = 86400L // 24 hours
+
+@Serializable
+data class TelegramWebAppUser(
+    val id: Long,
+    @SerialName("first_name")
+    val firstName: String? = null,
+    @SerialName("last_name")
+    val lastName: String? = null,
+    val username: String? = null,
+)
+
+data class VerifiedTelegramWebAppData(
+    val user: TelegramWebAppUser,
+    val authDate: Long,
+    val queryId: String?,
+    val startParam: String?,
+)
+
+object TelegramWebAppAuth {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Suppress("ReturnCount")
+    fun verifyInitData(
+        initData: String,
+        botToken: String,
+        maxAgeSeconds: Long = MAX_AUTH_AGE_SECONDS,
+    ): VerifiedTelegramWebAppData? {
+
+        if (initData.isBlank() || botToken.isBlank()) return null
+
+        val pairs = parseQueryString(initData)
+        val hash = pairs["hash"] ?: return null
+        if (!verifyHmac(pairs - "hash", hash, botToken)) return null
+
+        val authDate = pairs["auth_date"]?.toLongOrNull() ?: return null
+        if (!verifyAuthDate(authDate, maxAgeSeconds)) return null
+
+        val userJson = pairs["user"] ?: return null
+        val user = runCatching { json.decodeFromString<TelegramWebAppUser>(userJson) }.getOrNull() ?: return null
+
+        return VerifiedTelegramWebAppData(
+            user = user,
+            authDate = authDate,
+            queryId = pairs["query_id"],
+            startParam = pairs["start_param"],
+        )
+    }
+
+    private fun verifyHmac(
+        remainingPairs: Map<String, String>,
+        receivedHash: String,
+        botToken: String,
+    ): Boolean {
+        val dataCheckString = remainingPairs.entries
+            .sortedBy { it.key }
+            .joinToString("\n") { "${it.key}=${it.value}" }
+
+        val webAppDataBytes = "WebAppData".toByteArray(StandardCharsets.UTF_8)
+        val secretKey = hmacSha256(webAppDataBytes, botToken.toByteArray(StandardCharsets.UTF_8))
+        val calculatedHash = bytesToHex(hmacSha256(secretKey, dataCheckString.toByteArray(StandardCharsets.UTF_8)))
+
+        return constantTimeEquals(receivedHash.lowercase(), calculatedHash.lowercase())
+    }
+
+    private fun verifyAuthDate(authDate: Long, maxAgeSeconds: Long): Boolean {
+        val now = System.currentTimeMillis() / 1000
+        return now - authDate <= maxAgeSeconds
+    }
+
+    private fun parseQueryString(query: String): Map<String, String> {
+        val result = mutableMapOf<String, String>()
+        for (part in query.split("&")) {
+            val idx = part.indexOf('=')
+            if (idx > 0) {
+                val key = URLDecoder.decode(part.substring(0, idx), "UTF-8")
+                val value = URLDecoder.decode(part.substring(idx + 1), "UTF-8")
+                result[key] = value
+            }
+        }
+        return result
+    }
+
+    private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    private fun bytesToHex(bytes: ByteArray): String =
+        bytes.joinToString("") { "%02x".format(it) }
+
+    private fun constantTimeEquals(a: String, b: String): Boolean =
+        MessageDigest.isEqual(a.toByteArray(StandardCharsets.UTF_8), b.toByteArray(StandardCharsets.UTF_8))
+}

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramWebAppAuth.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramWebAppAuth.kt
@@ -76,7 +76,7 @@ object TelegramWebAppAuth {
 
     private fun verifyAuthDate(authDate: Long, maxAgeSeconds: Long): Boolean {
         val now = System.currentTimeMillis() / 1000
-        return now - authDate <= maxAgeSeconds
+        return authDate <= now && (now - authDate) <= maxAgeSeconds
     }
 
     private fun parseQueryString(query: String): Map<String, String> {

--- a/src/main/resources/db/migration/V7__webapp_sessions.sql
+++ b/src/main/resources/db/migration/V7__webapp_sessions.sql
@@ -1,0 +1,30 @@
+CREATE TABLE telegram_launch_nonces (
+    id UUID PRIMARY KEY,
+    nonce_digest BYTEA NOT NULL UNIQUE,
+    telegram_chat_id BIGINT NOT NULL,
+    telegram_topic_id BIGINT,
+    telegram_user_id BIGINT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX telegram_launch_nonces_expiry
+    ON telegram_launch_nonces (expires_at)
+    WHERE consumed_at IS NULL;
+
+CREATE TABLE webapp_sessions (
+    id UUID PRIMARY KEY,
+    telegram_user_id BIGINT NOT NULL,
+    telegram_chat_id BIGINT,
+    telegram_topic_id BIGINT,
+    token_digest BYTEA NOT NULL UNIQUE,
+    token_hash TEXT NOT NULL,
+    csrf_digest BYTEA NOT NULL,
+    csrf_hash TEXT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX webapp_sessions_expiry
+    ON webapp_sessions (expires_at);

--- a/src/test/kotlin/net/raquezha/nuecagram/BaseEventTestHelper.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/BaseEventTestHelper.kt
@@ -17,6 +17,8 @@ import net.raquezha.nuecagram.db.InstallationRecord
 import net.raquezha.nuecagram.db.InstallationRepository
 import net.raquezha.nuecagram.di.testAppModule
 import net.raquezha.nuecagram.plugins.configureRouting
+import net.raquezha.nuecagram.plugins.configureSerialization
+
 import net.raquezha.nuecagram.telegram.MockTelegramService
 import net.raquezha.nuecagram.telegram.TelegramService
 import net.raquezha.nuecagram.webhook.NuecagramHeaders.GITLAB_EVENT
@@ -43,9 +45,12 @@ abstract class BaseEventTestHelper : KoinTest {
 
     fun ApplicationTestBuilder.configureTestApplication() {
         application {
+            configureSerialization()
             configureRouting()
         }
     }
+
+
 
     @Before
     fun setUp() {

--- a/src/test/kotlin/net/raquezha/nuecagram/telegram/TelegramWebAppAuthTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/telegram/TelegramWebAppAuthTest.kt
@@ -1,0 +1,33 @@
+package net.raquezha.nuecagram.telegram
+
+import com.google.common.truth.Truth.assertThat
+import net.raquezha.nuecagram.testing.TelegramWebAppTestUtils.buildTestInitData
+import org.junit.Test
+
+class TelegramWebAppAuthTest {
+    @Test
+    fun verifiesValidTelegramWebAppInitDataHmac() {
+        val botToken = "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+        val initData = buildTestInitData(botToken)
+        val verified = TelegramWebAppAuth.verifyInitData(initData, botToken)
+        assertThat(verified).isNotNull()
+        assertThat(verified?.user?.id).isEqualTo(12345L)
+    }
+
+    @Test
+    fun rejectsTamperedTelegramWebAppInitDataHash() {
+        val botToken = "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+        val initData = buildTestInitData(botToken) + "&tampered=true"
+        val verified = TelegramWebAppAuth.verifyInitData(initData, botToken)
+        assertThat(verified).isNull()
+    }
+
+    @Test
+    fun rejectsExpiredAuthDate() {
+        val botToken = "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
+        val oldAuthDate = (System.currentTimeMillis() / 1000) - 90000 // > 24 hrs
+        val initData = buildTestInitData(botToken, authDate = oldAuthDate)
+        val verified = TelegramWebAppAuth.verifyInitData(initData, botToken)
+        assertThat(verified).isNull()
+    }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/testing/TelegramWebAppTestUtils.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/testing/TelegramWebAppTestUtils.kt
@@ -1,0 +1,42 @@
+package net.raquezha.nuecagram.testing
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+object TelegramWebAppTestUtils {
+    private fun hmacSha256(key: ByteArray, data: String): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private fun bytesToHex(bytes: ByteArray): String =
+        bytes.joinToString("") { "%02x".format(it) }
+
+    fun buildTestInitData(
+        botToken: String,
+        authDate: Long = System.currentTimeMillis() / 1000,
+        userId: Long = 12345L,
+        extraParams: Map<String, String> = emptyMap(),
+    ): String {
+        val secretKey = hmacSha256("WebAppData".toByteArray(StandardCharsets.UTF_8), botToken)
+        val baseParams = mutableMapOf(
+            "auth_date" to authDate.toString(),
+            "query_id" to "AAH12345",
+            "user" to """{"id":$userId,"first_name":"Test","last_name":"User"}""",
+        )
+        baseParams.putAll(extraParams)
+
+        val dataCheckString = baseParams.entries
+            .sortedBy { it.key }
+            .joinToString("\n") { "${it.key}=${it.value}" }
+
+        val hash = bytesToHex(hmacSha256(secretKey, dataCheckString))
+        val queryParams = baseParams + ("hash" to hash)
+        return queryParams.entries.joinToString("&") { (k, v) ->
+            "${URLEncoder.encode(k, "UTF-8")}=${URLEncoder.encode(v, "UTF-8")}"
+        }
+    }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/webapp/WebAppAuthEndpointTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/webapp/WebAppAuthEndpointTest.kt
@@ -1,0 +1,120 @@
+package net.raquezha.nuecagram.webapp
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import net.raquezha.nuecagram.BaseEventTestHelper
+import net.raquezha.nuecagram.ConfigWithSecrets
+import net.raquezha.nuecagram.testing.TelegramWebAppTestUtils.buildTestInitData
+import org.junit.Test
+import org.koin.test.inject
+
+@Serializable
+private data class TestAuthUser(
+    val id: Long,
+    val firstName: String? = null,
+    val username: String? = null,
+)
+
+@Serializable
+private data class TestAuthResponsePayload(
+    val success: Boolean,
+    val user: TestAuthUser,
+    val csrf: String,
+    val telegramChatId: Long? = null,
+    val telegramTopicId: Long? = null,
+)
+
+class WebAppAuthEndpointTest : BaseEventTestHelper() {
+
+    private val testConfig: ConfigWithSecrets by inject()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun webAppRouteReturnsHtmlContainerWithSecurityHeaders() = testApplication {
+        configureTestApplication()
+        val response = client.get("/nuecagram/webapp")
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(response.headers["Content-Type"]).contains("text/html")
+        assertThat(response.headers["Content-Security-Policy"]).contains("script-src 'self' https://telegram.org")
+        assertThat(response.headers["Cache-Control"]).contains("no-store")
+        val html = response.bodyAsText()
+        assertThat(html).contains("https://telegram.org/js/telegram-web-app.js")
+    }
+
+    @Test
+    fun authEndpointRejectsInvalidInitData() = testApplication {
+        configureTestApplication()
+        val response = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"invalid_data"}""")
+        }
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+        assertThat(response.bodyAsText()).contains("Invalid or expired initData signature")
+    }
+
+    @Test
+    fun authEndpointIssuesSessionCookieAndCsrfForValidInitData() = testApplication {
+        configureTestApplication()
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken)
+        val response = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData"}""")
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        val payload = json.decodeFromString<TestAuthResponsePayload>(response.bodyAsText())
+        assertThat(payload.success).isTrue()
+        assertThat(payload.user.id).isEqualTo(12345L)
+        assertThat(payload.csrf).isNotEmpty()
+
+        val setCookie = response.headers.getAll("Set-Cookie").orEmpty().joinToString("; ")
+        assertThat(setCookie).contains("nuecagram_webapp_session=")
+        assertThat(setCookie).contains("nuecagram_webapp_csrf=")
+    }
+
+    @Test
+    fun authEndpointConsumesLaunchNonceAndResolvesContext() = testApplication {
+        configureTestApplication()
+        val nonce = runBlocking {
+            installationRepository.issueLaunchNonce(
+                telegramChatId = -100123456L,
+                telegramTopicId = 42L,
+                telegramUserId = 12345L,
+                expiresAt = Instant.now().plus(10, ChronoUnit.MINUTES),
+            )
+        }
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken, userId = 12345L)
+
+        val response = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData","startParam":"nonce_${nonce.raw}"}""")
+        }
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        val payload1 = json.decodeFromString<TestAuthResponsePayload>(response.bodyAsText())
+        assertThat(payload1.telegramChatId).isEqualTo(-100123456L)
+        assertThat(payload1.telegramTopicId).isEqualTo(42L)
+
+        // Second attempt with same nonce fails context resolution (consumed)
+        val response2 = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData","startParam":"nonce_${nonce.raw}"}""")
+        }
+        assertThat(response2.status).isEqualTo(HttpStatusCode.OK)
+        val payload2 = json.decodeFromString<TestAuthResponsePayload>(response2.bodyAsText())
+        assertThat(payload2.telegramChatId).isNull()
+    }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt
@@ -1,0 +1,182 @@
+package net.raquezha.nuecagram.webapp
+
+import com.google.common.truth.Truth.assertThat
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import net.raquezha.nuecagram.BaseEventTestHelper
+import net.raquezha.nuecagram.ConfigWithSecrets
+import net.raquezha.nuecagram.testing.TelegramWebAppTestUtils.buildTestInitData
+import org.junit.Test
+import org.koin.test.inject
+
+@Serializable
+private data class DashboardTestAuthPayload(
+    val success: Boolean,
+    val csrf: String,
+)
+
+
+@Serializable
+private data class TestInstallationPayload(
+    val id: String,
+    val gitlabBaseUrl: String,
+    val telegramChatId: Long,
+    val telegramTopicId: Long? = null,
+    val muted: Boolean,
+)
+
+@Serializable
+private data class TestMuteResponsePayload(
+    val id: String,
+    val muted: Boolean,
+)
+
+@Serializable
+private data class TestActionResponsePayload(
+    val success: Boolean,
+    val message: String,
+)
+
+class WebDashboardTest : BaseEventTestHelper() {
+    private val testConfig: ConfigWithSecrets by inject()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun extractCookie(setCookieHeaders: List<String>, cookieName: String): String? =
+        setCookieHeaders.joinToString("; ").split(";")
+            .map { it.trim() }
+            .firstOrNull { it.startsWith("$cookieName=") }
+            ?.substringAfter("$cookieName=")
+
+    @Test
+    fun installationsEndpointRejectsUnauthenticatedRequests() = testApplication {
+        configureTestApplication()
+        val response = client.get("/nuecagram/api/webapp/installations")
+        assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun installationsEndpointReturnsFilteredListForAuthenticatedSession() = testApplication {
+        configureTestApplication()
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken, userId = 9999L)
+        val authResp = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData"}""")
+        }
+        assertThat(authResp.status).isEqualTo(HttpStatusCode.OK)
+
+        val setCookies = authResp.headers.getAll("Set-Cookie").orEmpty()
+        val sessionCookie = extractCookie(setCookies, "nuecagram_webapp_session")
+        assertThat(sessionCookie).isNotNull()
+
+        val listResp = client.get("/nuecagram/api/webapp/installations") {
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+        }
+        assertThat(listResp.status).isEqualTo(HttpStatusCode.OK)
+        val items = json.decodeFromString<List<TestInstallationPayload>>(listResp.bodyAsText())
+        assertThat(items).isNotEmpty()
+        assertThat(items.map { it.id }).contains(installation.id.toString())
+    }
+
+    @Test
+    fun installationDetailEndpointReturnsItemAndHandlesNotFound() = testApplication {
+        configureTestApplication()
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken, userId = 9999L)
+        val authResp = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData"}""")
+        }
+        val sessionCookie = extractCookie(authResp.headers.getAll("Set-Cookie").orEmpty(), "nuecagram_webapp_session")
+
+        val detailResp = client.get("/nuecagram/api/webapp/installations/${installation.id}") {
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+        }
+        assertThat(detailResp.status).isEqualTo(HttpStatusCode.OK)
+        val item = json.decodeFromString<TestInstallationPayload>(detailResp.bodyAsText())
+        assertThat(item.id).isEqualTo(installation.id.toString())
+
+        val notFoundResp = client.get("/nuecagram/api/webapp/installations/00000000-0000-0000-0000-000000000000") {
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+        }
+        assertThat(notFoundResp.status).isEqualTo(HttpStatusCode.NotFound)
+    }
+
+    @Test
+    fun muteEndpointRequiresCsrfAndUpdatesMuteStatus() = testApplication {
+        configureTestApplication()
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken, userId = 9999L)
+        val authResp = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData"}""")
+        }
+        val setCookies = authResp.headers.getAll("Set-Cookie").orEmpty()
+        val sessionCookie = extractCookie(setCookies, "nuecagram_webapp_session")
+        val csrfCookie = extractCookie(setCookies, "nuecagram_webapp_csrf")
+        val authPayload = json.decodeFromString<DashboardTestAuthPayload>(authResp.bodyAsText())
+
+
+        // Reject missing CSRF header
+        val rejectCsrfResp = client.post("/nuecagram/api/webapp/installations/${installation.id}/mute") {
+            contentType(ContentType.Application.Json)
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+            setBody("""{"muted":true}""")
+        }
+        assertThat(rejectCsrfResp.status).isEqualTo(HttpStatusCode.Forbidden)
+
+        // Accept valid CSRF header and toggle mute
+        val muteResp = client.post("/nuecagram/api/webapp/installations/${installation.id}/mute") {
+            contentType(ContentType.Application.Json)
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie; nuecagram_webapp_csrf=$csrfCookie")
+            header("X-CSRF-Token", authPayload.csrf)
+            setBody("""{"muted":true}""")
+        }
+        assertThat(muteResp.status).isEqualTo(HttpStatusCode.OK)
+        val mutePayload = json.decodeFromString<TestMuteResponsePayload>(muteResp.bodyAsText())
+        assertThat(mutePayload.muted).isTrue()
+
+        val updatedContext = runBlocking { installationRepository.installationAdminContext(installation.id) }
+        assertThat(updatedContext?.muted).isTrue()
+    }
+
+    @Test
+    fun testEndpointRequiresCsrfAndDispatchesTestMessage() = testApplication {
+        configureTestApplication()
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken, userId = 9999L)
+        val authResp = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData"}""")
+        }
+        val setCookies = authResp.headers.getAll("Set-Cookie").orEmpty()
+        val sessionCookie = extractCookie(setCookies, "nuecagram_webapp_session")
+        val csrfCookie = extractCookie(setCookies, "nuecagram_webapp_csrf")
+        val authPayload = json.decodeFromString<DashboardTestAuthPayload>(authResp.bodyAsText())
+
+
+        val testResp = client.post("/nuecagram/api/webapp/installations/${installation.id}/test") {
+            contentType(ContentType.Application.Json)
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie; nuecagram_webapp_csrf=$csrfCookie")
+            header("X-CSRF-Token", authPayload.csrf)
+        }
+        assertThat(testResp.status).isEqualTo(HttpStatusCode.OK)
+        val testPayload = json.decodeFromString<TestActionResponsePayload>(testResp.bodyAsText())
+        assertThat(testPayload.success).isTrue()
+
+        val delivered = sentMessages().last()
+        assertThat(delivered.chatId).isEqualTo(installation.telegramChatId.toString())
+        assertThat(delivered.text).contains(installation.id.toString())
+    }
+}

--- a/src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt
@@ -10,13 +10,15 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.server.testing.testApplication
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import kotlinx.coroutines.runBlocking
-
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import net.raquezha.nuecagram.BaseEventTestHelper
 import net.raquezha.nuecagram.ConfigWithSecrets
 import net.raquezha.nuecagram.testing.TelegramWebAppTestUtils.buildTestInitData
+import net.raquezha.nuecagram.telegram.MockTelegramService
 import org.junit.Test
 import org.koin.test.inject
 
@@ -25,7 +27,6 @@ private data class DashboardTestAuthPayload(
     val success: Boolean,
     val csrf: String,
 )
-
 
 @Serializable
 private data class TestInstallationPayload(
@@ -50,6 +51,8 @@ private data class TestActionResponsePayload(
 
 class WebDashboardTest : BaseEventTestHelper() {
     private val testConfig: ConfigWithSecrets by inject()
+    private val mockTelegramService: MockTelegramService
+        get() = telegramService as MockTelegramService
     private val json = Json { ignoreUnknownKeys = true }
 
     private fun extractCookie(setCookieHeaders: List<String>, cookieName: String): String? =
@@ -57,6 +60,36 @@ class WebDashboardTest : BaseEventTestHelper() {
             .map { it.trim() }
             .firstOrNull { it.startsWith("$cookieName=") }
             ?.substringAfter("$cookieName=")
+
+    private fun issueSessionWithNonce(
+        client: io.ktor.client.HttpClient,
+        userId: Long = 9999L,
+        chatId: Long = -100123456L,
+        topicId: Long? = null,
+    ): Pair<String, String> {
+        mockTelegramService.setChatMemberStatus(chatId, userId, "administrator")
+        val nonce = runBlocking {
+            installationRepository.issueLaunchNonce(
+                telegramChatId = chatId,
+                telegramTopicId = topicId,
+                telegramUserId = userId,
+                expiresAt = Instant.now().plus(10, ChronoUnit.MINUTES),
+            )
+        }
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken, userId = userId)
+        val authResp = runBlocking {
+            client.post("/nuecagram/api/webapp/auth") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"initData":"$initData","startParam":"nonce_${nonce.raw}"}""")
+            }
+        }
+        assertThat(authResp.status).isEqualTo(HttpStatusCode.OK)
+        val setCookies = authResp.headers.getAll("Set-Cookie").orEmpty()
+        val sessionCookie = extractCookie(setCookies, "nuecagram_webapp_session")!!
+        val authPayload = json.decodeFromString<DashboardTestAuthPayload>(runBlocking { authResp.bodyAsText() })
+        return Pair(sessionCookie, authPayload.csrf)
+    }
 
     @Test
     fun installationsEndpointRejectsUnauthenticatedRequests() = testApplication {
@@ -66,7 +99,7 @@ class WebDashboardTest : BaseEventTestHelper() {
     }
 
     @Test
-    fun installationsEndpointReturnsFilteredListForAuthenticatedSession() = testApplication {
+    fun installationsEndpointReturnsEmptyListForUnscopedSession() = testApplication {
         configureTestApplication()
         val botToken = testConfig.botApi
         val initData = buildTestInitData(botToken, userId = 9999L)
@@ -74,11 +107,26 @@ class WebDashboardTest : BaseEventTestHelper() {
             contentType(ContentType.Application.Json)
             setBody("""{"initData":"$initData"}""")
         }
-        assertThat(authResp.status).isEqualTo(HttpStatusCode.OK)
-
         val setCookies = authResp.headers.getAll("Set-Cookie").orEmpty()
         val sessionCookie = extractCookie(setCookies, "nuecagram_webapp_session")
-        assertThat(sessionCookie).isNotNull()
+
+        val listResp = client.get("/nuecagram/api/webapp/installations") {
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+        }
+        assertThat(listResp.status).isEqualTo(HttpStatusCode.OK)
+        val items = json.decodeFromString<List<TestInstallationPayload>>(listResp.bodyAsText())
+        assertThat(items).isEmpty()
+    }
+
+    @Test
+    fun installationsEndpointReturnsFilteredListForScopedSession() = testApplication {
+        configureTestApplication()
+        val (sessionCookie, _) = issueSessionWithNonce(
+            client,
+            userId = 9999L,
+            chatId = installation.telegramChatId,
+            topicId = installation.telegramTopicId,
+        )
 
         val listResp = client.get("/nuecagram/api/webapp/installations") {
             header("Cookie", "nuecagram_webapp_session=$sessionCookie")
@@ -90,15 +138,14 @@ class WebDashboardTest : BaseEventTestHelper() {
     }
 
     @Test
-    fun installationDetailEndpointReturnsItemAndHandlesNotFound() = testApplication {
+    fun installationDetailEndpointEnforcesSessionContextScope() = testApplication {
         configureTestApplication()
-        val botToken = testConfig.botApi
-        val initData = buildTestInitData(botToken, userId = 9999L)
-        val authResp = client.post("/nuecagram/api/webapp/auth") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"initData":"$initData"}""")
-        }
-        val sessionCookie = extractCookie(authResp.headers.getAll("Set-Cookie").orEmpty(), "nuecagram_webapp_session")
+        val (sessionCookie, _) = issueSessionWithNonce(
+            client,
+            userId = 9999L,
+            chatId = installation.telegramChatId,
+            topicId = installation.telegramTopicId,
+        )
 
         val detailResp = client.get("/nuecagram/api/webapp/installations/${installation.id}") {
             header("Cookie", "nuecagram_webapp_session=$sessionCookie")
@@ -107,26 +154,27 @@ class WebDashboardTest : BaseEventTestHelper() {
         val item = json.decodeFromString<TestInstallationPayload>(detailResp.bodyAsText())
         assertThat(item.id).isEqualTo(installation.id.toString())
 
-        val notFoundResp = client.get("/nuecagram/api/webapp/installations/00000000-0000-0000-0000-000000000000") {
-            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+        val (wrongContextSession, _) = issueSessionWithNonce(
+            client,
+            userId = 9999L,
+            chatId = -999L,
+        )
+
+        val forbiddenDetailResp = client.get("/nuecagram/api/webapp/installations/${installation.id}") {
+            header("Cookie", "nuecagram_webapp_session=$wrongContextSession")
         }
-        assertThat(notFoundResp.status).isEqualTo(HttpStatusCode.NotFound)
+        assertThat(forbiddenDetailResp.status).isEqualTo(HttpStatusCode.NotFound)
     }
 
     @Test
     fun muteEndpointRequiresCsrfAndUpdatesMuteStatus() = testApplication {
         configureTestApplication()
-        val botToken = testConfig.botApi
-        val initData = buildTestInitData(botToken, userId = 9999L)
-        val authResp = client.post("/nuecagram/api/webapp/auth") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"initData":"$initData"}""")
-        }
-        val setCookies = authResp.headers.getAll("Set-Cookie").orEmpty()
-        val sessionCookie = extractCookie(setCookies, "nuecagram_webapp_session")
-        val csrfCookie = extractCookie(setCookies, "nuecagram_webapp_csrf")
-        val authPayload = json.decodeFromString<DashboardTestAuthPayload>(authResp.bodyAsText())
-
+        val (sessionCookie, csrf) = issueSessionWithNonce(
+            client,
+            userId = 9999L,
+            chatId = installation.telegramChatId,
+            topicId = installation.telegramTopicId,
+        )
 
         // Reject missing CSRF header
         val rejectCsrfResp = client.post("/nuecagram/api/webapp/installations/${installation.id}/mute") {
@@ -139,8 +187,8 @@ class WebDashboardTest : BaseEventTestHelper() {
         // Accept valid CSRF header and toggle mute
         val muteResp = client.post("/nuecagram/api/webapp/installations/${installation.id}/mute") {
             contentType(ContentType.Application.Json)
-            header("Cookie", "nuecagram_webapp_session=$sessionCookie; nuecagram_webapp_csrf=$csrfCookie")
-            header("X-CSRF-Token", authPayload.csrf)
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+            header("X-CSRF-Token", csrf)
             setBody("""{"muted":true}""")
         }
         assertThat(muteResp.status).isEqualTo(HttpStatusCode.OK)
@@ -154,22 +202,17 @@ class WebDashboardTest : BaseEventTestHelper() {
     @Test
     fun testEndpointRequiresCsrfAndDispatchesTestMessage() = testApplication {
         configureTestApplication()
-        val botToken = testConfig.botApi
-        val initData = buildTestInitData(botToken, userId = 9999L)
-        val authResp = client.post("/nuecagram/api/webapp/auth") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"initData":"$initData"}""")
-        }
-        val setCookies = authResp.headers.getAll("Set-Cookie").orEmpty()
-        val sessionCookie = extractCookie(setCookies, "nuecagram_webapp_session")
-        val csrfCookie = extractCookie(setCookies, "nuecagram_webapp_csrf")
-        val authPayload = json.decodeFromString<DashboardTestAuthPayload>(authResp.bodyAsText())
-
+        val (sessionCookie, csrf) = issueSessionWithNonce(
+            client,
+            userId = 9999L,
+            chatId = installation.telegramChatId,
+            topicId = installation.telegramTopicId,
+        )
 
         val testResp = client.post("/nuecagram/api/webapp/installations/${installation.id}/test") {
             contentType(ContentType.Application.Json)
-            header("Cookie", "nuecagram_webapp_session=$sessionCookie; nuecagram_webapp_csrf=$csrfCookie")
-            header("X-CSRF-Token", authPayload.csrf)
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+            header("X-CSRF-Token", csrf)
         }
         assertThat(testResp.status).isEqualTo(HttpStatusCode.OK)
         val testPayload = json.decodeFromString<TestActionResponsePayload>(testResp.bodyAsText())
@@ -178,5 +221,43 @@ class WebDashboardTest : BaseEventTestHelper() {
         val delivered = sentMessages().last()
         assertThat(delivered.chatId).isEqualTo(installation.telegramChatId.toString())
         assertThat(delivered.text).contains(installation.id.toString())
+    }
+
+    @Test
+    fun webAppJsScriptIsServedWithSecurityHeaders() = testApplication {
+        configureTestApplication()
+        val response = client.get("/nuecagram/webapp/app.js")
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+        assertThat(response.headers["Content-Type"]).contains("javascript")
+        assertThat(response.headers["Cache-Control"]).contains("no-store")
+        val js = response.bodyAsText()
+        assertThat(js).contains("initWebApp()")
+        assertThat(js).contains("loadInstallations()")
+    }
+
+    @Test
+    fun nonAdminUserIsRejectedWithForbidden() = testApplication {
+        configureTestApplication()
+        mockTelegramService.setChatMemberStatus(installation.telegramChatId, 7777L, "member")
+        val nonce = runBlocking {
+            installationRepository.issueLaunchNonce(
+                telegramChatId = installation.telegramChatId,
+                telegramTopicId = installation.telegramTopicId,
+                telegramUserId = 7777L,
+                expiresAt = Instant.now().plus(10, ChronoUnit.MINUTES),
+            )
+        }
+        val botToken = testConfig.botApi
+        val initData = buildTestInitData(botToken, userId = 7777L)
+        val authResp = client.post("/nuecagram/api/webapp/auth") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"initData":"$initData","startParam":"nonce_${nonce.raw}"}""")
+        }
+        val sessionCookie = extractCookie(authResp.headers.getAll("Set-Cookie").orEmpty(), "nuecagram_webapp_session")
+
+        val listResp = client.get("/nuecagram/api/webapp/installations") {
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+        }
+        assertThat(listResp.status).isEqualTo(HttpStatusCode.Forbidden)
     }
 }


### PR DESCRIPTION
## Summary
- Enforced session context scoping across Web App installation listing, detail, mute, and test endpoints.
- Re-used Telegram group admin verification for Web App management actions and corrected audit `actorId` to store Telegram user IDs.
- Added production Web App launch nonce issuance via `/webapp` command in group/topic chats.
- Fixed Web App UI execution under CSP by serving static JavaScript at `/webapp/app.js` and removing malformed inline handlers.
- Rejected future `auth_date` timestamps in `initData` validation and added comprehensive regression tests in `WebDashboardTest`.

## Scope
- `src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt`
- `src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt`
- `src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramWebAppAuth.kt`
- `src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt`

## Verification
- [x] `./gradlew test --tests "net.raquezha.nuecagram.webapp.WebDashboardTest"`
- [x] `./gradlew test --tests "net.raquezha.nuecagram.webapp.WebAppAuthEndpointTest"`
- [x] `./gradlew lintKotlinMain lintKotlinTest`
- [x] `./gradlew detekt`
- [x] `./gradlew test`
- [x] `./gradlew build`
- [x] `./gradlew clean test`

## Risk / Rollback
- Risk: Low (all Web App management actions are now strictly admin-authorized and scoped to current Telegram launch context).
- Rollback: Revert commit `e22d28e` on `feat/102`.

## RPIV Task
- Task: `github:102`
- Slice: Repair Slices 1-5 Complete
- Branch: `feat/102`

## Human Review Checklist
- [x] Review changed files for repo conventions.
- [x] Confirm verification evidence is sufficient.
- [x] Confirm no secrets, local-only paths, or scratch artifacts are included.
