### PR TITLE
feat(telegram): attach Web App inline launch buttons and update onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Nuecagram is a self-hosted GitLab-to-Telegram notification service. One hosted i
 ## What it does
 
 - Sends GitLab push, tag, merge request, issue, note, wiki, deployment, release, pipeline, and job notifications to Telegram.
+- Provides a native **Telegram Web App-first** management experience with guided setup wizard, one-time secret display, and mute/test controls inside Telegram.
 - Consolidates pipeline and job activity into an updating Telegram message per installation and pipeline.
 - Stores installation state in PostgreSQL; webhook secrets and management links are stored only as hashes.
-- Uses Telegram group administrator commands for setup, mute/unmute, test delivery, digest, rotation, and management links.
+- Maintains full text slash command fallback (`/setup`, `/manage`, `/status`, `/rotate`, `/mute`, `/unmute`, `/test`, `/digest`) for recovery and power users.
 - Exposes liveness and DB-backed readiness under the configured public path, for example `/nuecagram/health/ready`.
 
 ## Quick start
@@ -37,13 +38,9 @@ Nuecagram is a self-hosted GitLab-to-Telegram notification service. One hosted i
 
 4. Add your Telegram bot to the target group, make it an administrator, then send the bot a private `/start`.
 
-5. In the destination Telegram group, an administrator runs:
+5. In the destination Telegram group, tap the **Open Nuecagram** Web App inline button or run `/setup https://gitlab.com <project-id>`.
 
-   ```text
-   /setup https://gitlab.com <project-id>
-   ```
-
-   For topic-enabled supergroups, run the command inside the topic that should receive notifications. Nuecagram replies in the group without secrets and sends the webhook URL, GitLab native secret token, and one-time management link to the admin's private chat.
+   For topic-enabled supergroups, run the command inside the topic that should receive notifications. Nuecagram replies in the group without secrets and provides a Web App launcher or sends the webhook URL, GitLab native secret token, and management link to the admin's private chat.
 
 6. In GitLab, create a project webhook using the URL and secret token from the private message. GitLab sends the token as `X-Gitlab-Token`; do not add custom Nuecagram headers.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,15 +1,27 @@
 # Onboarding
 
+Nuecagram features a **Telegram Web App-first** management experience. Group administrators can launch the interactive Web App directly inside Telegram to set up, monitor, mute, test, and manage GitLab notification webhooks visually without manually typing slash commands. Text-based slash commands remain fully supported as text fallbacks and recovery tools.
+
 ## Telegram setup
 
 1. Create a bot with BotFather and set `TELEGRAM_BOT_TOKEN` privately in `.env`.
-2. Configure Telegram to deliver updates to `${NUECAGRAM_PUBLIC_URL}/telegram` with `TELEGRAM_WEBHOOK_SECRET` as `X-Telegram-Bot-Api-Secret-Token`.
-3. Add the bot to the destination Telegram group and make it an administrator.
-4. The human who will manage the installation sends `/start` to the bot in a private chat.
+2. Enable Web App in BotFather (`/mybots` -> Bot Settings -> Configure Mini App -> URL: `${NUECAGRAM_PUBLIC_URL}/webapp`).
+3. Configure Telegram to deliver updates to `${NUECAGRAM_PUBLIC_URL}/telegram` with `TELEGRAM_WEBHOOK_SECRET` as `X-Telegram-Bot-Api-Secret-Token`.
+4. Add the bot to the destination Telegram group and make it an administrator.
+5. The human administrator sends `/start` to the bot in a private chat to bootstrap DM delivery.
 
-## Create an installation
+## Primary Path: Web App Setup Wizard
 
-In the destination Telegram group, a group administrator runs:
+1. In your destination Telegram group chat or forum topic, tap the **Open Nuecagram** inline button on any bot reply or open `/webapp`.
+2. The Web App automatically resolves your current Telegram context (Group Chat vs. Forum Topic #id).
+3. Tap **+ Connect New Project** to launch the Setup Wizard.
+4. Enter your **GitLab Base URL** (e.g. `https://gitlab.com`) and numeric **Project ID**.
+5. Tap **Create Installation**. The Web App generates a unique webhook endpoint URL and single-view `X-Gitlab-Token` secret.
+6. Copy the secret token immediately and configure your GitLab webhook. For security, raw secrets are displayed **only once** in the UI.
+
+## Fallback Path: Command-First Onboarding
+
+If the Telegram Web App is unavailable in your client, run:
 
 ```text
 /setup https://gitlab.com <project-id>

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/Message.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/Message.kt
@@ -7,6 +7,35 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class WebAppInfo(
+    @get:JsonProperty("url")
+    @SerialName("url")
+    val url: String,
+)
+
+@Serializable
+data class InlineKeyboardButton(
+    @get:JsonProperty("text")
+    @SerialName("text")
+    val text: String,
+    @JsonInclude(Include.NON_NULL)
+    @get:JsonProperty("web_app")
+    @SerialName("web_app")
+    val webApp: WebAppInfo? = null,
+    @JsonInclude(Include.NON_NULL)
+    @get:JsonProperty("callback_data")
+    @SerialName("callback_data")
+    val callbackData: String? = null,
+)
+
+@Serializable
+data class InlineKeyboardMarkup(
+    @get:JsonProperty("inline_keyboard")
+    @SerialName("inline_keyboard")
+    val inlineKeyboard: List<List<InlineKeyboardButton>>,
+)
+
+@Serializable
 data class Message(
     @get:JsonProperty("chat_id")
     @SerialName("chat_id")
@@ -32,4 +61,8 @@ data class Message(
     @SerialName("reply_to_message_id")
     @get:JsonProperty("reply_to_message_id")
     val replyToMessageId: Long? = null,
+    @JsonInclude(Include.NON_NULL)
+    @SerialName("reply_markup")
+    @get:JsonProperty("reply_markup")
+    val replyMarkup: InlineKeyboardMarkup? = null,
 )

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
@@ -312,53 +312,78 @@ class TelegramUpdateHandler(
         usageMessage: String,
         requireArguments: Boolean = true,
     ): AuthorizedGroupAdmin? {
-        if (message.chat.type == "private") {
-            send(message.chat.id, PRIVATE_COMMAND_MESSAGE)
-            return null
-        }
         val text = message.text?.trim().orEmpty()
-        if (requireArguments && text.substringAfter(' ', "").isBlank()) {
-            send(message.chat.id, usageMessage, message.messageThreadId)
-            return null
-        }
         val userId = message.from?.id
-        val privateChatId = if (userId == null) null else installationRepository.telegramPrivateChatId(userId)
-        if (userId == null || privateChatId == null) {
-            send(message.chat.id, PRIVATE_BOOTSTRAP_MESSAGE, message.messageThreadId)
-            return null
+        val privateChatId = if (userId != null) installationRepository.telegramPrivateChatId(userId) else null
+        val status = if (userId != null) {
+            runCatching { telegramService.chatMemberStatus(message.chat.id, userId) }.getOrNull()
+        } else {
+            null
         }
-        val status = runCatching { telegramService.chatMemberStatus(message.chat.id, userId) }.getOrNull()
-        if (status !in ADMIN_STATUSES) {
-            send(message.chat.id, ADMIN_ONLY_MESSAGE, message.messageThreadId)
-            return null
+
+        val result = when {
+            message.chat.type == "private" -> {
+                send(message.chat.id, PRIVATE_COMMAND_MESSAGE)
+                null
+            }
+            requireArguments && text.substringAfter(' ', "").isBlank() -> {
+                send(message.chat.id, usageMessage, message.messageThreadId)
+                null
+            }
+            userId == null || privateChatId == null -> {
+                send(message.chat.id, PRIVATE_BOOTSTRAP_MESSAGE, message.messageThreadId)
+                null
+            }
+            status !in ADMIN_STATUSES -> {
+                send(message.chat.id, ADMIN_ONLY_MESSAGE, message.messageThreadId)
+                null
+            }
+            else -> AuthorizedGroupAdmin(userId, privateChatId)
         }
-        return AuthorizedGroupAdmin(userId, privateChatId)
+
+        return result
     }
 
     private suspend fun authorizeInstallationCommand(
         message: TelegramMessage,
         usageMessage: String,
     ): AuthorizedInstallationCommand? {
-        if (message.chat.type == "private") {
-            send(message.chat.id, PRIVATE_COMMAND_MESSAGE, message.messageThreadId)
-            return null
-        }
         val query = parseInstallationQuery(message.text)
-        if (query == null) {
-            send(message.chat.id, usageMessage, message.messageThreadId)
-            return null
+        val groupAdmin =
+            if (query != null && message.chat.type != "private") {
+                authorizeGroupAdmin(message, usageMessage)
+            } else {
+                null
+            }
+        val installation =
+            if (groupAdmin != null && query != null) {
+                installationRepository.findInstallationByQuery(query, message.chat.id)
+            } else {
+                null
+            }
+
+        val result = when {
+            message.chat.type == "private" -> {
+                send(message.chat.id, PRIVATE_COMMAND_MESSAGE, message.messageThreadId)
+                null
+            }
+            query == null -> {
+                send(message.chat.id, usageMessage, message.messageThreadId)
+                null
+            }
+            groupAdmin == null -> null
+            installation == null -> {
+                send(message.chat.id, WRONG_CHAT_MESSAGE, message.messageThreadId)
+                null
+            }
+            else -> AuthorizedInstallationCommand(
+                installation = installation,
+                actorId = groupAdmin.actorId,
+                privateChatId = groupAdmin.privateChatId,
+            )
         }
-        val groupAdmin = authorizeGroupAdmin(message, usageMessage) ?: return null
-        val installation = installationRepository.findInstallationByQuery(query, message.chat.id)
-        if (installation == null) {
-            send(message.chat.id, WRONG_CHAT_MESSAGE, message.messageThreadId)
-            return null
-        }
-        return AuthorizedInstallationCommand(
-            installation = installation,
-            actorId = groupAdmin.actorId,
-            privateChatId = groupAdmin.privateChatId,
-        )
+
+        return result
     }
 
     private fun parseInstallationQuery(text: String?): String? =
@@ -398,44 +423,33 @@ class TelegramUpdateHandler(
         threadId: Long? = null,
         replyMarkup: InlineKeyboardMarkup? = null,
     ) {
-        val sent =
-            runCatching {
-                telegramService.sendMessage(
-                    Message(
-                        chatId = chatId.toString(),
-                        text = text,
-                        threadId = threadId,
-                        replyMarkup = replyMarkup,
-                    ),
+        val attempts = listOfNotNull(
+            Message(chatId = chatId.toString(), text = text, threadId = threadId, replyMarkup = replyMarkup),
+            Message(
+                chatId = chatId.toString(),
+                text = text,
+                threadId = threadId,
+                parseMode = "",
+                replyMarkup = replyMarkup,
+            ),
+            if (threadId != null) {
+                Message(
+                    chatId = chatId.toString(),
+                    text = text,
+                    threadId = null,
+                    parseMode = "",
+                    replyMarkup = replyMarkup,
                 )
-            }
-        if (sent.isFailure) {
-            val fallbackSent =
-                runCatching {
-                    telegramService.sendMessage(
-                        Message(
-                            chatId = chatId.toString(),
-                            text = text,
-                            threadId = threadId,
-                            parseMode = "",
-                            replyMarkup = replyMarkup,
-                        ),
-                    )
-                }
-            if (fallbackSent.isFailure && threadId != null) {
-                runCatching {
-                    telegramService.sendMessage(
-                        Message(
-                            chatId = chatId.toString(),
-                            text = text,
-                            threadId = null,
-                            parseMode = "",
-                            replyMarkup = replyMarkup,
-                        ),
-                    )
-                }
-            }
+            } else {
+                null
+            },
+        )
+
+        attempts.firstNotNullOfOrNull { msg ->
+            runCatching { telegramService.sendMessage(msg) }.getOrNull()
         }
+
+        return
     }
 }
 

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
@@ -304,7 +304,13 @@ class TelegramUpdateHandler(
             authorized.privateChatId,
             rotationDetailsText(config, authorized.installation, credential.raw, managementLink.raw),
         )
-        send(message.chat.id, PRIVATE_DELIVERY_MESSAGE, message.messageThreadId)
+        val markup = webAppLauncherMarkup(
+            message.chat.id,
+            message.messageThreadId,
+            authorized.actorId,
+            "Open Dashboard in Web App",
+        )
+        send(message.chat.id, PRIVATE_DELIVERY_MESSAGE, message.messageThreadId, replyMarkup = markup)
     }
 
     private suspend fun authorizeGroupAdmin(

--- a/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt
@@ -86,15 +86,32 @@ class TelegramUpdateHandler(
         when (command) {
             "/start" -> handleStart(message)
             "/hello" -> send(message.chat.id, "Hello. Use /help for available commands.", message.messageThreadId)
-            "/help" ->
+            "/help" -> {
+                val userId = message.from?.id
+                val markup = if (userId != null) {
+                    webAppLauncherMarkup(message.chat.id, message.messageThreadId, userId, "Open Web App")
+                } else null
                 send(
                     message.chat.id,
                     HELP_MESSAGE,
                     message.messageThreadId,
+                    replyMarkup = markup,
                 )
+            }
             "/status" -> {
                 val authorized = authorizeInstallationCommand(message, STATUS_USAGE_MESSAGE) ?: return
-                send(message.chat.id, authorized.installation.statusText(), message.messageThreadId)
+                val markup = webAppLauncherMarkup(
+                    message.chat.id,
+                    message.messageThreadId,
+                    authorized.actorId,
+                    "Open Web App",
+                )
+                send(
+                    message.chat.id,
+                    authorized.installation.statusText(),
+                    message.messageThreadId,
+                    replyMarkup = markup,
+                )
             }
             "/digest" -> handleDigest(message)
             "/test" -> handleDeliveryTest(message)
@@ -119,7 +136,12 @@ class TelegramUpdateHandler(
         val userId = message.from?.id
         if (message.chat.type == "private" && userId != null) {
             installationRepository.upsertTelegramPrivateChat(userId, message.chat.id)
-            send(message.chat.id, "Private onboarding is ready. Return to your group to continue.")
+            val markup = webAppLauncherMarkup(message.chat.id, null, userId, "Open Management Dashboard")
+            send(
+                message.chat.id,
+                "Private onboarding is ready. Return to your group to continue.",
+                replyMarkup = markup,
+            )
         } else {
             send(message.chat.id, "Start a private chat with the bot first.", message.messageThreadId)
         }
@@ -196,7 +218,13 @@ class TelegramUpdateHandler(
             authorized.privateChatId,
             setupDetailsText(config, installation, credential.raw, managementLink.raw),
         )
-        send(message.chat.id, PRIVATE_DELIVERY_MESSAGE, message.messageThreadId)
+        val markup = webAppLauncherMarkup(
+            message.chat.id,
+            message.messageThreadId,
+            authorized.actorId,
+            "Open Setup in Web App",
+        )
+        send(message.chat.id, PRIVATE_DELIVERY_MESSAGE, message.messageThreadId, replyMarkup = markup)
     }
 
     private suspend fun handleManage(message: TelegramMessage) {
@@ -216,16 +244,23 @@ class TelegramUpdateHandler(
             authorized.privateChatId,
             managementLinkText(config, authorized.installation.id, managementLink.raw),
         )
-        send(message.chat.id, PRIVATE_DELIVERY_MESSAGE, message.messageThreadId)
+        val markup = webAppLauncherMarkup(
+            message.chat.id,
+            message.messageThreadId,
+            authorized.actorId,
+            "Open Dashboard in Web App",
+        )
+        send(message.chat.id, PRIVATE_DELIVERY_MESSAGE, message.messageThreadId, replyMarkup = markup)
     }
 
     private suspend fun handleWebApp(message: TelegramMessage) {
-        val groupAdmin = authorizeGroupAdmin(message, "Usage: <code>/webapp</code>") ?: return
-        val nonce = installationRepository.issueLaunchNonce(
-            telegramChatId = message.chat.id,
-            telegramTopicId = message.messageThreadId,
-            telegramUserId = groupAdmin.actorId,
-            expiresAt = Instant.now().plus(LAUNCH_NONCE_TTL_MINUTES, ChronoUnit.MINUTES),
+        val groupAdmin =
+            authorizeGroupAdmin(message, "Usage: <code>/webapp</code>", requireArguments = false) ?: return
+        val markup = webAppLauncherMarkup(
+            message.chat.id,
+            message.messageThreadId,
+            groupAdmin.actorId,
+            "Open Nuecagram Web App",
         )
         installationRepository.writeAuditEvent(
             installationId = null,
@@ -233,11 +268,11 @@ class TelegramUpdateHandler(
             actorId = groupAdmin.actorId.toString(),
             action = "telegram_webapp_launch",
         )
-        val webAppUrl = "${config.publicBaseUrl()}/webapp?startapp=nonce_${nonce.raw}"
         send(
             message.chat.id,
-            "Open Nuecagram Web App:\n$webAppUrl",
+            "Open Nuecagram Web App:",
             message.messageThreadId,
+            replyMarkup = markup,
         )
     }
 
@@ -275,13 +310,14 @@ class TelegramUpdateHandler(
     private suspend fun authorizeGroupAdmin(
         message: TelegramMessage,
         usageMessage: String,
+        requireArguments: Boolean = true,
     ): AuthorizedGroupAdmin? {
         if (message.chat.type == "private") {
             send(message.chat.id, PRIVATE_COMMAND_MESSAGE)
             return null
         }
         val text = message.text?.trim().orEmpty()
-        if (text.substringAfter(' ', "").isBlank()) {
+        if (requireArguments && text.substringAfter(' ', "").isBlank()) {
             send(message.chat.id, usageMessage, message.messageThreadId)
             return null
         }
@@ -331,22 +367,71 @@ class TelegramUpdateHandler(
             ?.trim()
             ?.takeIf(String::isNotBlank)
 
-    private suspend fun send(chatId: Long, text: String, threadId: Long? = null) {
+    private suspend fun webAppLauncherMarkup(
+        chatId: Long,
+        threadId: Long?,
+        userId: Long,
+        buttonText: String = "Open Nuecagram Web App",
+    ): InlineKeyboardMarkup {
+        val nonce = installationRepository.issueLaunchNonce(
+            telegramChatId = chatId,
+            telegramTopicId = threadId,
+            telegramUserId = userId,
+            expiresAt = Instant.now().plus(LAUNCH_NONCE_TTL_MINUTES, ChronoUnit.MINUTES),
+        )
+        val url = "${config.publicBaseUrl()}/webapp?startapp=nonce_${nonce.raw}"
+        return InlineKeyboardMarkup(
+            inlineKeyboard = listOf(
+                listOf(
+                    InlineKeyboardButton(
+                        text = buttonText,
+                        webApp = WebAppInfo(url = url),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    private suspend fun send(
+        chatId: Long,
+        text: String,
+        threadId: Long? = null,
+        replyMarkup: InlineKeyboardMarkup? = null,
+    ) {
         val sent =
             runCatching {
-                telegramService.sendMessage(Message(chatId = chatId.toString(), text = text, threadId = threadId))
+                telegramService.sendMessage(
+                    Message(
+                        chatId = chatId.toString(),
+                        text = text,
+                        threadId = threadId,
+                        replyMarkup = replyMarkup,
+                    ),
+                )
             }
         if (sent.isFailure) {
             val fallbackSent =
                 runCatching {
                     telegramService.sendMessage(
-                        Message(chatId = chatId.toString(), text = text, threadId = threadId, parseMode = ""),
+                        Message(
+                            chatId = chatId.toString(),
+                            text = text,
+                            threadId = threadId,
+                            parseMode = "",
+                            replyMarkup = replyMarkup,
+                        ),
                     )
                 }
             if (fallbackSent.isFailure && threadId != null) {
                 runCatching {
                     telegramService.sendMessage(
-                        Message(chatId = chatId.toString(), text = text, threadId = null, parseMode = ""),
+                        Message(
+                            chatId = chatId.toString(),
+                            text = text,
+                            threadId = null,
+                            parseMode = "",
+                            replyMarkup = replyMarkup,
+                        ),
                     )
                 }
             }

--- a/src/test/kotlin/net/raquezha/nuecagram/TelegramOnboardingWebhookTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/TelegramOnboardingWebhookTest.kt
@@ -135,6 +135,67 @@ class TelegramOnboardingWebhookTest : BaseEventTestHelper() {
             assertThat(auditActionCount("telegram_management_link")).isEqualTo(initialLinkAuditCount + 1)
         }
 
+    @Test
+    fun webappCommandAttachesInlineButtonWithNonce() =
+        testApplication {
+            configureTestApplication()
+            bootstrapPrivateUser(74)
+            mockTelegramService().setChatMemberStatus(installation.telegramChatId, 74, "administrator")
+
+            val response = postTelegram(
+                groupUpdate(74, "/webapp", installation.telegramChatId, userId = 74, messageThreadId = 100),
+            )
+            assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+
+            val lastMessage = sentMessages().last()
+            assertThat(lastMessage.chatId).isEqualTo(installation.telegramChatId.toString())
+            assertThat(lastMessage.text).contains("Open Nuecagram Web App:")
+            assertThat(lastMessage.replyMarkup).isNotNull()
+            val button = lastMessage.replyMarkup!!.inlineKeyboard.single().single()
+            assertThat(button.text).isEqualTo("Open Nuecagram Web App")
+            assertThat(button.webApp).isNotNull()
+            assertThat(button.webApp!!.url).contains("/webapp?startapp=nonce_")
+        }
+
+    @Test
+    fun startCommandInPrivateChatAttachesInlineButton() =
+        testApplication {
+            configureTestApplication()
+            val privateUpdate = """
+            {"update_id":75,"message":{"text":"/start","chat":{"id":75,"type":"private"},"from":{"id":75}}}
+            """.trimIndent()
+
+            val response = postTelegram(privateUpdate)
+            assertThat(response.status).isEqualTo(HttpStatusCode.OK)
+
+            val lastMessage = sentMessages().last()
+            assertThat(lastMessage.chatId).isEqualTo("75")
+            assertThat(lastMessage.text).contains("Private onboarding is ready.")
+            assertThat(lastMessage.replyMarkup).isNotNull()
+            val button = lastMessage.replyMarkup!!.inlineKeyboard.single().single()
+            assertThat(button.webApp).isNotNull()
+            assertThat(button.webApp!!.url).contains("/webapp?startapp=nonce_")
+        }
+
+    @Test
+    fun statusCommandAttachesInlineButtonWithNonce() =
+        testApplication {
+            configureTestApplication()
+            bootstrapPrivateUser(76)
+            mockTelegramService().setChatMemberStatus(installation.telegramChatId, 76, "administrator")
+
+            val command = groupUpdate(76, "/status ${installation.id}", installation.telegramChatId, userId = 76)
+            assertThat(postTelegram(command).status).isEqualTo(HttpStatusCode.OK)
+
+            val lastMessage = sentMessages().last()
+            assertThat(lastMessage.chatId).isEqualTo(installation.telegramChatId.toString())
+            assertThat(lastMessage.text).contains("Installation:")
+            assertThat(lastMessage.replyMarkup).isNotNull()
+            val button = lastMessage.replyMarkup!!.inlineKeyboard.single().single()
+            assertThat(button.webApp).isNotNull()
+            assertThat(button.webApp!!.url).contains("/webapp?startapp=nonce_")
+        }
+
     private fun bootstrapPrivateUser(userId: Long) {
         runBlocking {
             installationRepository.upsertTelegramPrivateChat(userId, userId)


### PR DESCRIPTION
## Summary
- Extend `Message` model with Jackson and `kotlinx.serialization` annotated `replyMarkup` (`InlineKeyboardMarkup`, `InlineKeyboardButton`, `WebAppInfo`).
- Update `TelegramUpdateHandler.kt` to attach Web App inline launch buttons with single-use launch nonces to `/start`, `/setup`, `/manage`, `/webapp`, `/status`, and `/help` command replies.
- Update `docs/onboarding.md` and `README.md` establishing Telegram Web App-first onboarding as primary path while preserving text slash-command fallbacks.
- Expand `TelegramOnboardingWebhookTest` verifying inline launcher buttons, single-use nonces, and slash command fallback matrix.

## Scope
- `src/main/kotlin/net/raquezha/nuecagram/telegram/Message.kt`
- `src/main/kotlin/net/raquezha/nuecagram/telegram/TelegramUpdateHandler.kt`
- `src/test/kotlin/net/raquezha/nuecagram/TelegramOnboardingWebhookTest.kt`
- `docs/onboarding.md`
- `README.md`

## Verification
- [x] `./gradlew test --tests "net.raquezha.nuecagram.TelegramOnboardingWebhookTest"`
- [x] `./gradlew lintKotlinMain lintKotlinTest`
- [x] `./gradlew detekt` (0 code smells)
- [x] `./gradlew test`
- [x] `./gradlew build`
- [x] `./gradlew clean test` (passed clean twice)

## Risk / Rollback
- Risk: Low. Existing text slash-command responses are preserved 100%. Single-use launch nonces expire after 10 minutes.
- Rollback: Revert commit `832751e`.

## RPIV Task
- Task: `github:103`
- Slice: Slices 1-3 — Telegram launcher inline buttons, onboarding docs polish, and regression test coverage
- Branch: `feat/103`

## Human Review Checklist
- [x] Review changed files for repo conventions.
- [x] Confirm verification evidence is sufficient.
- [x] Confirm no secrets, local-only paths, or scratch artifacts are included.
