### PR TITLE
fix(webapp): allow creation of target group installations from DM webapp context

### DIFF
--- a/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
+++ b/src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt
@@ -94,6 +94,8 @@ private data class ErrorResponsePayload(
 private data class CreateInstallationRequestPayload(
     val gitlabBaseUrl: String,
     val gitlabProjectId: Long,
+    val telegramChatId: Long? = null,
+    val telegramTopicId: Long? = null,
 )
 
 @Serializable
@@ -255,7 +257,8 @@ private suspend fun ApplicationCall.handleGetInstallations(
     val session = authenticateWebAppSession(installationRepository) ?: return
     if (!verifyAdminStatus(session, telegramService)) return
 
-    val items = if (session.telegramChatId != null) {
+    val isGroupContext = session.telegramChatId != null && session.telegramChatId < 0
+    val items = if (isGroupContext) {
         installationRepository.listInstallationsForContext(session.telegramChatId, session.telegramTopicId)
     } else {
         val adminChatIds = mutableMapOf<Long, Boolean>()
@@ -389,6 +392,52 @@ private suspend fun ApplicationCall.handleCreateInstallation(
     }
 }
 
+private suspend fun ApplicationCall.respondError(
+    status: HttpStatusCode,
+    error: String,
+): WebAppResponseSpec? {
+    respond(status, ErrorResponsePayload(error))
+    return null
+}
+
+private data class TargetDestination(val chatId: Long?, val topicId: Long?)
+
+private fun resolveTargetDestination(
+    session: WebAppSessionContext,
+    parsed: CreateInstallationRequestPayload?,
+): TargetDestination {
+    val isGroup = session.telegramChatId != null && session.telegramChatId < 0
+    return TargetDestination(
+        chatId = if (isGroup) session.telegramChatId else parsed?.telegramChatId,
+        topicId = if (isGroup) session.telegramTopicId else parsed?.telegramTopicId,
+    )
+}
+
+private suspend fun resolveDmId(
+    session: WebAppSessionContext,
+    repository: InstallationRepository,
+): Long? {
+    val isDmSession = session.telegramChatId != null &&
+        session.telegramChatId > 0 &&
+        session.telegramChatId == session.telegramUserId
+    return if (isDmSession) {
+        session.telegramUserId
+    } else {
+        repository.telegramPrivateChatId(session.telegramUserId)
+    }
+}
+
+private suspend fun isTargetAdmin(
+    session: WebAppSessionContext,
+    targetChatId: Long?,
+    telegramService: TelegramService,
+): Boolean {
+    if (session.telegramChatId != null && session.telegramChatId < 0) return true
+    if (targetChatId == null || targetChatId >= 0) return true
+    val status = runCatching { telegramService.chatMemberStatus(targetChatId, session.telegramUserId) }.getOrNull()
+    return status in ADMIN_STATUSES
+}
+
 private suspend fun ApplicationCall.processCreateInstallation(
     installationRepository: InstallationRepository,
     telegramService: TelegramService,
@@ -400,48 +449,62 @@ private suspend fun ApplicationCall.processCreateInstallation(
     if (!verifyAdminStatus(session, telegramService)) return null
     if (!verifyCsrfHeader(installationRepository, session)) return null
 
-    val chatId = session.telegramChatId
-    val dmId = if (chatId != null) installationRepository.telegramPrivateChatId(session.telegramUserId) else null
     val bodyText = receiveText()
     val parsed = runCatching { json.decodeFromString<CreateInstallationRequestPayload>(bodyText) }.getOrNull()
+    val target = resolveTargetDestination(session, parsed)
+    val dmId = resolveDmId(session, installationRepository)
 
     return when {
-        chatId == null -> {
-            respond(HttpStatusCode.BadRequest, ErrorResponsePayload("Session has no Telegram context"))
-            null
-        }
-        dmId == null -> {
-            respond(HttpStatusCode.Forbidden, ErrorResponsePayload("DM bootstrap required"))
-            null
-        }
-        parsed == null || parsed.gitlabBaseUrl.isBlank() -> {
-            respond(HttpStatusCode.BadRequest, ErrorResponsePayload("Missing or invalid payload"))
-            null
-        }
-        !parsed.gitlabBaseUrl.startsWith("https://") -> {
-            respond(HttpStatusCode.BadRequest, ErrorResponsePayload("gitlabBaseUrl must start with https://"))
-            null
-        }
-        else -> {
-            val installation = installationRepository.createInstallation(
-                gitlabBaseUrl = parsed.gitlabBaseUrl.trimEnd('/'),
-                gitlabProjectId = parsed.gitlabProjectId,
-                telegramChatId = chatId,
-                telegramTopicId = session.telegramTopicId,
+        dmId == null -> respondError(HttpStatusCode.Forbidden, "DM bootstrap required")
+        target.chatId == null || target.chatId >= 0 ->
+            respondError(HttpStatusCode.BadRequest, "Valid target Telegram group chat ID required")
+        !isTargetAdmin(session, target.chatId, telegramService) ->
+            respondError(
+                HttpStatusCode.Forbidden,
+                "Telegram group administrator permissions required for target group",
             )
-            val tok = installationRepository.issueWebhookSecret(installation.id)
-            installationRepository.writeAuditEvent(
-                installationId = installation.id,
-                actorType = "webapp_session",
-                actorId = session.telegramUserId.toString(),
-                action = "webapp_setup",
-            )
-            WebAppResponseSpec(
-                HttpStatusCode.Created,
-                toCreateResponse(installation, tok, config.webhookEndpointUrl(basePath)),
-            )
-        }
+        parsed == null || parsed.gitlabBaseUrl.isBlank() ->
+            respondError(HttpStatusCode.BadRequest, "Missing or invalid payload")
+        !parsed.gitlabBaseUrl.startsWith("https://") ->
+            respondError(HttpStatusCode.BadRequest, "gitlabBaseUrl must start with https://")
+        else -> createAndRespond(
+            installationRepository = installationRepository,
+            config = config,
+            basePath = basePath,
+            parsed = parsed,
+            targetChatId = target.chatId,
+            targetTopicId = target.topicId,
+            telegramUserId = session.telegramUserId,
+        )
     }
+}
+
+private suspend fun createAndRespond(
+    installationRepository: InstallationRepository,
+    config: ConfigWithSecrets,
+    basePath: String,
+    parsed: CreateInstallationRequestPayload,
+    targetChatId: Long,
+    targetTopicId: Long?,
+    telegramUserId: Long,
+): WebAppResponseSpec {
+    val installation = installationRepository.createInstallation(
+        gitlabBaseUrl = parsed.gitlabBaseUrl.trimEnd('/'),
+        gitlabProjectId = parsed.gitlabProjectId,
+        telegramChatId = targetChatId,
+        telegramTopicId = targetTopicId,
+    )
+    val tok = installationRepository.issueWebhookSecret(installation.id)
+    installationRepository.writeAuditEvent(
+        installationId = installation.id,
+        actorType = "webapp_session",
+        actorId = telegramUserId.toString(),
+        action = "webapp_setup",
+    )
+    return WebAppResponseSpec(
+        HttpStatusCode.Created,
+        toCreateResponse(installation, tok, config.webhookEndpointUrl(basePath)),
+    )
 }
 
 private fun toCreateResponse(
@@ -478,7 +541,7 @@ private suspend fun ApplicationCall.processRotateInstallation(
     if (!verifyAdminStatus(session, telegramService)) return null
     if (!verifyCsrfHeader(installationRepository, session)) return null
 
-    val dmId = installationRepository.telegramPrivateChatId(session.telegramUserId)
+    val dmId = resolveDmId(session, installationRepository)
     val idParam = parameters["id"]?.let { runCatching { UUID.fromString(it) }.getOrNull() }
     val item = if (idParam != null) installationRepository.installationAdminContext(idParam) else null
 
@@ -516,7 +579,7 @@ private suspend fun canAccess(
     item: InstallationAdminContext,
     telegramService: TelegramService,
 ): Boolean {
-    if (session.telegramChatId != null) {
+    if (session.telegramChatId != null && session.telegramChatId < 0) {
         if (item.telegramChatId != session.telegramChatId) return false
         if (session.telegramTopicId != null && item.telegramTopicId != session.telegramTopicId) return false
         return true
@@ -532,6 +595,7 @@ private suspend fun ApplicationCall.verifyAdminStatus(
     telegramService: TelegramService,
 ): Boolean {
     val chatId = session.telegramChatId ?: return true
+    if (chatId > 0) return true
     val status = runCatching { telegramService.chatMemberStatus(chatId, session.telegramUserId) }.getOrNull()
     if (status !in ADMIN_STATUSES) {
         respond(HttpStatusCode.Forbidden, ErrorResponsePayload("Telegram group administrator permissions required"))

--- a/src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt
+++ b/src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt
@@ -49,6 +49,13 @@ private data class TestActionResponsePayload(
     val message: String,
 )
 
+@Serializable
+private data class TestCreateInstallationResponsePayload(
+    val installation: TestInstallationPayload,
+    val credential: String,
+    val webhookUrl: String,
+)
+
 class WebDashboardTest : BaseEventTestHelper() {
     private val testConfig: ConfigWithSecrets by inject()
     private val mockTelegramService: MockTelegramService
@@ -302,5 +309,37 @@ class WebDashboardTest : BaseEventTestHelper() {
             header("Cookie", "nuecagram_webapp_session=$sessionCookie")
         }
         assertThat(listResp.status).isEqualTo(HttpStatusCode.Forbidden)
+    }
+
+    @Test
+    fun createInstallationInDmSessionWithTargetChatId() = testApplication {
+        configureTestApplication()
+        val targetChatId = -100987654L
+        mockTelegramService.setChatMemberStatus(targetChatId, 9999L, "administrator")
+        val (sessionCookie, csrf) = issueSessionWithNonce(
+            client,
+            userId = 9999L,
+            chatId = 9999L,
+            topicId = null,
+        )
+
+        val createResp = client.post("/nuecagram/api/webapp/installations") {
+            contentType(ContentType.Application.Json)
+            header("Cookie", "nuecagram_webapp_session=$sessionCookie")
+            header("X-CSRF-Token", csrf)
+            setBody(
+                """
+                {
+                    "gitlabBaseUrl": "https://gitlab.example.com",
+                    "gitlabProjectId": 456,
+                    "telegramChatId": $targetChatId
+                }
+                """.trimIndent(),
+            )
+        }
+        assertThat(createResp.status).isEqualTo(HttpStatusCode.Created)
+        val created = json.decodeFromString<TestCreateInstallationResponsePayload>(createResp.bodyAsText())
+        assertThat(created.installation.telegramChatId).isEqualTo(targetChatId)
+        assertThat(created.installation.gitlabBaseUrl).isEqualTo("https://gitlab.example.com")
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `telegramChatId` and `telegramTopicId` to `CreateInstallationRequestPayload` so unscoped DM web app clients can create installations for targeted group chats.
- Refactor installation creation and rotate endpoints in `WebAppRouting.kt` with clean helper functions and `when` expressions, resolving detekt code smells.
- Add unit test verifying DM web app session creation of group installations with target chat ID.

Closes #112

## Scope
- `src/main/kotlin/net/raquezha/nuecagram/plugins/WebAppRouting.kt`
- `src/test/kotlin/net/raquezha/nuecagram/webapp/WebDashboardTest.kt`

## Verification
- [x] `./gradlew lintKotlinMain lintKotlinTest`
- [x] `./gradlew detekt`
- [x] `./gradlew test`
- [x] `./gradlew build`

## Risk / Rollback
- Risk: Low (operations strictly check user admin status for target Telegram groups and enforce DM context resolution).
- Rollback: Revert commit 90a0120.